### PR TITLE
Multi-GPU pool placement (Phase 1b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,37 @@ must be a list). Any error is logged and the gateway refuses to start.
 legacy `ALLOWED_MODELS_JSON` env var with the global `VLLM_*` settings — behaving exactly as
 before this feature existed.
 
+## Multi-GPU pools
+
+One gateway can manage several GPUs by declaring a `pools:` section and assigning each model to a
+pool with `pool:`. Get the full UUIDs from `nvidia-smi -L`.
+
+```yaml
+pools:
+  llm:  [GPU-aaaa-…]   # RTX 3090 — LLMs
+  util: [GPU-bbbb-…]   # RTX A2000 — small/utility models
+defaults: { pool: llm, gpu_memory_utilization: 0.90 }
+models:
+  qwen3-30b-awq: { repo: …, quantization: awq, pool: llm }
+  small-util:    { repo: …, pool: util, gpu_memory_utilization: 0.45 }
+```
+
+- **Placement.** On each request the gateway picks a GPU *within the model's pool*: a card with
+  enough free VRAM (tie-break: most free); if none fits, it evicts idle models (LRU, never
+  `always_on` or in-flight) on a pool GPU; if it still can't fit, it returns **503** (it never
+  over-commits and risks an OOM). Per-GPU accounting uses *actual* free VRAM from `nvidia-smi`, so
+  it tolerates VRAM used by processes the gateway didn't start.
+- **Whole-card model.** This release does **not** tensor-parallel or co-locate multiple models on
+  one card — each model gets ~its whole GPU at its `gpu_memory_utilization`.
+- **GPU source precedence.** `pools:` in config → else `GATEWAY_GPU_UUID` (a single-GPU pool) →
+  else all visible GPUs (the legacy single-pool behavior). When no `pools:` are declared, behavior
+  is unchanged.
+- **Embeddings/rerankers** are expected to run **out of band** — a separate always-on
+  [TEI](https://github.com/huggingface/text-embeddings-inference) or
+  [infinity](https://github.com/michaelfeil/infinity) container pinned to the A2000 — **not**
+  through this swapping gateway. The gateway's `util` pool can still place small models on the same
+  A2000 because it reads the card's real free VRAM. See `/gateway/status` for per-GPU pool/usage/residents.
+
 ## Configuration
 
 All configuration is done via environment variables, making it easy to deploy with Portainer, Kubernetes, or directly from GitHub.

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -8,7 +8,25 @@
 # Resolution precedence per setting:
 #   per-model entry  >  defaults block  >  built-in default (the old env var)
 
+# --- GPU pools (optional, multi-GPU) ---------------------------------------
+# Declare the GPUs this gateway manages and group them into named pools. Get the
+# full UUIDs from `nvidia-smi -L`. A model is placed on a GPU within its pool.
+#   - If 'pools' is omitted, the gateway runs single-pool: the GATEWAY_GPU_UUID
+#     pin if set, else all visible GPUs (unchanged legacy behavior).
+#   - Tensor-parallel and multi-model co-location are not yet supported: each model
+#     gets ~its whole GPU at its gpu_memory_utilization (whole-card placement).
+# NOTE: Embeddings/rerankers are expected to run OUT OF BAND — a separate always-on
+# TEI/infinity container pinned to the A2000 — NOT through this gateway. They are
+# therefore intentionally absent below. The gateway's 'util' pool reads the A2000's
+# real free VRAM (via nvidia-smi), so it accounts for that external embedder.
+pools:
+  llm:                                   # RTX 3090 — LLMs
+    - GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+  util:                                  # RTX A2000 — small/utility models (shares card with embedder)
+    - GPU-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+
 defaults:                      # optional; applied to every model unless overridden
+  pool: llm                    # default pool for models that don't set one
   gpu_memory_utilization: 0.90 # 0 < x <= 1
   max_model_len: 0             # 0 = use the model's native max (omit the flag)
   tensor_parallel_size: 1
@@ -19,14 +37,15 @@ defaults:                      # optional; applied to every model unless overrid
   extra_args: []               # raw vLLM CLI args, appended verbatim (override generated flags)
 
 models:                        # required, non-empty
-  # A small instruct model on its native context length.
+  # A small instruct model on its native context length (default pool: llm).
   gemma3-4B:
     repo: google/gemma-3-4b-it
 
-  # An AWQ-quantized model.
+  # An AWQ-quantized model on the LLM pool.
   qwen3-30b-awq:
     repo: cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit
     quantization: awq
+    pool: llm
 
   # A model pinned to a custom (capped) context length and a couple of extra flags.
   qwen2.5-coder:
@@ -35,8 +54,8 @@ models:                        # required, non-empty
     extra_args:
       - "--enable-prefix-caching"
 
-  # An always-on embedding model that is never unloaded by the inactivity monitor.
-  bge-m3:
-    repo: BAAI/bge-m3
-    always_on: true
-    inactivity_timeout: 0
+  # A small utility model placed on the A2000 'util' pool (e.g. a captioning/OCR helper).
+  small-util:
+    repo: Qwen/Qwen2.5-3B-Instruct
+    pool: util
+    gpu_memory_utilization: 0.45   # leave headroom for the external embedder on the A2000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,9 +23,11 @@ services:
       # Path to the per-model config (mounted read-only at /app/config below).
       MODELS_CONFIG_FILE: ${MODELS_CONFIG_FILE:-/app/config/models.yaml}
 
-      # --- GPU PINNING ---
-      # Leave blank to use all GPUs (default). Set to a UUID from `nvidia-smi -L` to
-      # pin this gateway instance, and every vLLM container it launches, to one GPU.
+      # --- GPU PINNING / POOLS ---
+      # For multi-GPU, declare a 'pools:' section in models.yaml (one gateway manages
+      # several GPUs and places each model on a GPU in its pool). For a single GPU, leave
+      # GATEWAY_GPU_UUID blank to use all GPUs, or set it to a UUID from `nvidia-smi -L`
+      # to pin this gateway (and every container it launches) to one GPU. 'pools' wins if set.
       GATEWAY_GPU_UUID: ${GATEWAY_GPU_UUID:-}
 
       # --- NETWORKING ---

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -12,11 +12,14 @@ from fastapi import FastAPI, Request, HTTPException
 from fastapi.responses import JSONResponse, StreamingResponse
 from docker.types import DeviceRequest
 from docker.errors import NotFound, APIError
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from huggingface_hub import hf_hub_download, list_repo_files
 import yaml
 import placement
-from config_loader import ModelConfig, resolve_model_configs, build_fallback_configs
+from config_loader import (
+    ModelConfig, resolve_model_configs, build_fallback_configs,
+    resolve_pools, validate_model_pools,
+)
 
 # --- Logging Configuration ---
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
@@ -120,6 +123,14 @@ model_management_lock = asyncio.Lock()  # For updating active_containers dict
 container_start_locks = {}  # model_id -> asyncio.Lock for preventing concurrent container starts
 download_locks = {}  # model_id -> asyncio.Lock for preventing concurrent downloads
 
+# Multi-GPU placement state (resolved at startup; see resolve_managed_pools)
+MANAGED_POOLS = {}  # pool_name -> [gpu_uuid, ...]: the GPUs this gateway manages, grouped into pools
+MANAGED_GPUS = []   # flat list of managed gpu_uuids (union of MANAGED_POOLS values)
+gpu_reservations = {}  # gpu_uuid -> reserved MiB for models that are loading (not yet nvidia-smi visible)
+# Single global lock held ONLY for the placement decision (choose GPU + reserve), never across a
+# container start. Acquire order: container_start_locks[model] -> model_management_lock -> placement_lock.
+placement_lock = asyncio.Lock()
+
 # Queue management state
 model_semaphores = {}  # model_id -> asyncio.Semaphore for limiting concurrent requests
 model_queue_counts = {}  # model_id -> int (number of requests waiting in queue)
@@ -137,6 +148,7 @@ class ContainerState:
     always_on: bool = False  # if True, never auto-unloaded by the inactivity monitor
     inactivity_timeout: int = VLLM_INACTIVITY_TIMEOUT  # per-model idle timeout (seconds; 0 = never unload)
     loaded_at: float = 0.0  # time.time() when the container became ready (for anti-thrash cooldown)
+    gpu_uuids: list = field(default_factory=list)  # GPU UUID(s) this container is pinned to
 
 # --- Docker and HTTP Clients ---
 docker_client = docker.from_env()
@@ -190,6 +202,7 @@ async def lifespan(_app: FastAPI):
         logging.error(f"Gateway container '{GATEWAY_CONTAINER_NAME}' not found. Falling back to network '{DOCKER_NETWORK_NAME}'.")
 
     await get_total_vram()
+    resolve_managed_pools()
     load_known_footprints()
     asyncio.create_task(shutdown_inactive_containers())
 
@@ -212,14 +225,22 @@ async def run_in_executor(func, *args, **kwargs):
     return await loop.run_in_executor(None, partial(func, *args, **kwargs))
 
 async def run_nvidia_smi_in_container(command: list[str]) -> str:
-    """Runs an nvidia-smi command in a temporary container and returns the output."""
+    """Runs an nvidia-smi command in a temporary container and returns the output.
+
+    The probe must see every GPU this gateway manages so per-GPU accounting is complete.
+    Once pools are resolved it requests exactly the managed set; before that (startup) it
+    falls back to GPU_DEVICE_REQUESTS (the GATEWAY_GPU_UUID pin, or all GPUs)."""
+    if MANAGED_GPUS:
+        probe_requests = [DeviceRequest(device_ids=list(MANAGED_GPUS), capabilities=[['gpu']])]
+    else:
+        probe_requests = GPU_DEVICE_REQUESTS
     try:
         smi_output = await run_in_executor(
             docker_client.containers.run,
             NVIDIA_UTILITY_IMAGE,
             command=command,
             remove=True,
-            device_requests=GPU_DEVICE_REQUESTS
+            device_requests=probe_requests
         )
         return smi_output.decode('utf-8').strip()
     except APIError as e:
@@ -319,6 +340,37 @@ async def get_used_vram() -> float:
         logging.error("Could not determine used GPU VRAM.")
         return 0.0
     return float(_managed_vram(gpus, "used"))
+
+DEFAULT_POOL = "_default"  # implicit pool used in the single-pool / backward-compatible cases
+
+def resolve_managed_pools():
+    """Resolve which GPUs this gateway manages and how they're grouped into pools.
+
+    Precedence: (1) a 'pools:' section in the model config; (2) GATEWAY_GPU_UUID (one implicit
+    single-GPU pool); (3) all visible GPUs (one implicit pool — today's single-pool behavior).
+    Runs at startup after get_total_vram() has populated GPU_VRAM."""
+    global MANAGED_POOLS, MANAGED_GPUS
+    if CONFIGURED_POOLS:
+        MANAGED_POOLS = {name: list(uuids) for name, uuids in CONFIGURED_POOLS.items()}
+        source = f"config 'pools' ({len(MANAGED_POOLS)} pool(s))"
+    elif GATEWAY_GPU_UUID:
+        MANAGED_POOLS = {DEFAULT_POOL: [GATEWAY_GPU_UUID]}
+        source = f"GATEWAY_GPU_UUID pin ({GATEWAY_GPU_UUID})"
+    else:
+        MANAGED_POOLS = {DEFAULT_POOL: list(GPU_VRAM.keys())}
+        source = f"all visible GPUs ({len(GPU_VRAM)})"
+    MANAGED_GPUS = [u for uuids in MANAGED_POOLS.values() for u in uuids]
+    logging.info(f"Managed GPU pools resolved from {source}: "
+                 f"{ {p: u for p, u in MANAGED_POOLS.items()} }")
+    # Warn about configured UUIDs the probe can't see (typo / wrong host).
+    if GPU_VRAM:
+        unseen = [u for u in MANAGED_GPUS if u not in GPU_VRAM]
+        if unseen:
+            logging.warning(f"Configured GPU UUID(s) not visible to nvidia-smi: {unseen}")
+
+def pool_for(model_cfg) -> str:
+    """The pool a model belongs to: its configured pool, else the default/implicit pool."""
+    return model_cfg.pool if model_cfg.pool else DEFAULT_POOL
 
 def is_gguf_model(model_id: str) -> bool:
     """Check if the model_id refers to a GGUF file."""
@@ -486,13 +538,15 @@ def builtin_model_defaults() -> dict:
         "inactivity_timeout": VLLM_INACTIVITY_TIMEOUT,
         "always_on": False,
         "extra_args": [],
+        "pool": None,
     }
 
-def load_model_configs() -> "dict[str, ModelConfig]":
-    """Load per-model configuration.
+def load_model_configs() -> "tuple[dict, dict]":
+    """Load per-model configuration and any declared GPU pools.
 
     Uses MODELS_CONFIG_FILE (YAML) when it exists; otherwise falls back to the legacy
     ALLOWED_MODELS_JSON env var with built-in defaults (behaves exactly as before).
+    Returns (configs, pools); pools is {} unless a 'pools:' section is present.
     Raises on a malformed config file so the gateway fails fast at startup.
     """
     builtins = builtin_model_defaults()
@@ -504,8 +558,12 @@ def load_model_configs() -> "dict[str, ModelConfig]":
         if not raw:
             raise ValueError(f"Model config file '{MODELS_CONFIG_FILE}' is empty or not valid YAML")
         configs = resolve_model_configs(raw, builtins)
+        pools = resolve_pools(raw)
+        validate_model_pools(configs, pools)  # fail fast on a model referencing an undeclared pool
         logging.info(f"Loaded {len(configs)} model(s) from {MODELS_CONFIG_FILE}: {list(configs)}")
-        return configs
+        if pools:
+            logging.info(f"Declared GPU pools: { {p: len(u) for p, u in pools.items()} }")
+        return configs, pools
 
     if MODELS_CONFIG_FILE and os.path.isdir(MODELS_CONFIG_FILE):
         # A directory at the mount target usually means Docker created a missing file mount.
@@ -516,10 +574,10 @@ def load_model_configs() -> "dict[str, ModelConfig]":
     configs = build_fallback_configs(allowed, builtins)
     logging.info(f"No model config file at '{MODELS_CONFIG_FILE}'; using ALLOWED_MODELS_JSON fallback "
                  f"({len(configs)} model(s)): {list(configs)}")
-    return configs
+    return configs, {}
 
 # Resolve model configuration at import time so a bad config fails fast (refuses to start).
-MODEL_CONFIGS = load_model_configs()
+MODEL_CONFIGS, CONFIGURED_POOLS = load_model_configs()
 # name -> repo map, preserved for existing lookups throughout the app.
 ALLOWED_MODELS = {name: cfg.repo for name, cfg in MODEL_CONFIGS.items()}
 
@@ -648,8 +706,12 @@ def merge_extra_args(base: "list[str]", extra: "list[str]") -> "list[str]":
     merged.extend(extra)
     return merged
 
-async def start_model_container(model_id: str, container_name: str, model_cfg: ModelConfig) -> ContainerState | None:
-    """Starts a new vLLM container using the model's resolved configuration."""
+async def start_model_container(model_id: str, container_name: str, model_cfg: ModelConfig,
+                                gpu_uuids: "list[str] | None" = None) -> ContainerState | None:
+    """Starts a new vLLM container using the model's resolved configuration.
+
+    gpu_uuids pins the container to specific GPU(s) (multi-GPU placement). When None/empty,
+    falls back to GPU_DEVICE_REQUESTS (the gateway-wide pin or all GPUs) for backward compat."""
     logging.info(f"Attempting to start model {model_id} in container {container_name}")
 
     # Clean up any existing container with the same name (from crashes or improper shutdowns)
@@ -783,7 +845,13 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
     try:
         vllm_image = get_vllm_image_for_model(model_id)
         logging.info(f"Using vLLM image: {vllm_image} for model {model_id}")
-        logging.info(f"Starting container {container_name} with command: {' '.join(command)}")
+        # Pin to the chosen GPU(s) when placement supplied them; else gateway-wide default.
+        if gpu_uuids:
+            device_requests = [DeviceRequest(device_ids=list(gpu_uuids), capabilities=[['gpu']])]
+        else:
+            device_requests = GPU_DEVICE_REQUESTS
+        logging.info(f"Starting container {container_name} on GPU(s) {gpu_uuids or 'default'} "
+                     f"with command: {' '.join(command)}")
         new_container = await run_in_executor(
             docker_client.containers.run,
             vllm_image,
@@ -798,7 +866,7 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
                 "VLLM_CACHE_BUST": str(uuid.uuid4()),
             },
             ipc_mode="host",
-            device_requests=GPU_DEVICE_REQUESTS,
+            device_requests=device_requests,
             volumes={
                 HOST_CACHE_DIR: {'bind': '/root/.cache/huggingface', 'mode': 'rw'},
                 VLLM_TEMP_DIR: {'bind': '/tmp', 'mode': 'rw'}  # For temporary GGUF downloads
@@ -859,6 +927,7 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
                         always_on=model_cfg.always_on,
                         inactivity_timeout=model_cfg.inactivity_timeout,
                         loaded_at=time.time(),
+                        gpu_uuids=list(gpu_uuids) if gpu_uuids else [],
                     )
                 elif response.status_code != 503:
                     # 503 is expected during vLLM initialization; anything else is worth noting
@@ -895,8 +964,23 @@ def list_models():
 @app.get("/gateway/status")
 def gateway_status():
     """Returns the current status of the gateway and its managed containers."""
+    # Per-GPU view: which pool each managed GPU is in, its residents, and reservation.
+    uuid_to_pool = {u: p for p, uuids in MANAGED_POOLS.items() for u in uuids}
+    gpus_status = {}
+    for guid in MANAGED_GPUS:
+        v = GPU_VRAM.get(guid, {})
+        residents = [c.container_name for c in active_containers.values() if guid in c.gpu_uuids]
+        gpus_status[guid] = {
+            "pool": uuid_to_pool.get(guid),
+            "total_mib": v.get("total"),
+            "used_mib": v.get("used"),
+            "reserved_mib": gpu_reservations.get(guid, 0.0),
+            "residents": residents,
+        }
     return {
         "total_gpu_vram_mib": TOTAL_GPU_VRAM,
+        "pools": MANAGED_POOLS,
+        "gpus": gpus_status,
         "known_footprints_mib": known_footprints,
         "active_containers": {name: state.__dict__ for name, state in active_containers.items()},
         "queue_status": {
@@ -1013,107 +1097,98 @@ async def proxy_request(request: Request):
                         # 2. Model not running, need to start it
                         footprint = known_footprints.get(target_model_id)
 
-                        if footprint is None and TOTAL_GPU_VRAM > 0:
-                            # DISCOVERY RUN
-                            logging.info(f"Unknown footprint for {target_model_id}. Starting a discovery run.")
+                        if TOTAL_GPU_VRAM > 0:
+                            # POOL-BASED PLACEMENT (whole-card model; no TP, no co-location).
+                            # known_footprints: None = never seen (discovery), 0 = seen-but-unmeasurable
+                            # sentinel, >0 = measured. is_discovery only when truly unseen.
+                            is_discovery = footprint is None
+                            pool = pool_for(model_cfg)
+                            pool_gpus = MANAGED_POOLS.get(pool, [])
+                            if not pool_gpus:
+                                raise HTTPException(status_code=500,
+                                                    detail=f"Pool '{pool}' for model {target_model_id} has no managed GPUs")
 
-                            # Stop active containers to isolate the measurement, but never an
-                            # always_on model. Leaving an always_on model resident is safe for the
-                            # footprint delta (it's present in both the before and after samples, so
-                            # it cancels out); it only reduces headroom for the discovery load.
+                            # Snapshot per-GPU VRAM OUTSIDE the placement lock (it spawns a container).
+                            gpus_snapshot = await get_gpu_vram()
+
+                            # --- DECIDE: choose a GPU + reserve, under the global placement lock ---
                             async with model_management_lock:
-                                container_names_to_stop = [
-                                    name for name, c in active_containers.items() if not c.always_on
-                                ]
-                                if container_names_to_stop:
-                                    logging.info(f"Stopping {len(container_names_to_stop)} container(s) for discovery run (always_on kept).")
+                                async with placement_lock:
+                                    candidates = []
+                                    residents_by_gpu = {}
+                                    for guid in pool_gpus:
+                                        g = gpus_snapshot.get(guid)
+                                        residents = [c for c in active_containers.values() if guid in c.gpu_uuids]
+                                        residents_by_gpu[guid] = residents
+                                        candidates.append(placement.GpuView(
+                                            uuid=guid,
+                                            total=float(g["total"]) if g else 0.0,
+                                            used_smi=float(g["used"]) if g else 0.0,
+                                            reserved=gpu_reservations.get(guid, 0.0),
+                                            ready_footprint=sum(c.vram_footprint for c in residents),
+                                        ))
+                                    # Whole-card estimate when the footprint isn't a measured number.
+                                    if footprint and footprint > 0:
+                                        needed_est = float(footprint)
+                                    else:
+                                        max_total = max((c.total for c in candidates), default=0.0)
+                                        needed_est = model_cfg.gpu_memory_utilization * max_total
 
-                            # Stop containers outside lock (I/O operation)
-                            for name in container_names_to_stop:
+                                    chosen_uuid, evictions = placement.select_gpu(
+                                        candidates, residents_by_gpu, needed_est,
+                                        time.time(), GATEWAY_MIN_RESIDENT_SECONDS,
+                                    )
+                                    if chosen_uuid is None:
+                                        raise HTTPException(
+                                            status_code=503,
+                                            detail=(f"No GPU in pool '{pool}' can fit model {target_model_id} "
+                                                    f"(~{int(needed_est)} MiB) without evicting always_on/in-flight models. Retry later."))
+
+                                    gpu_reservations[chosen_uuid] = gpu_reservations.get(chosen_uuid, 0.0) + needed_est
+                                    slot_indices = {int(name.split('_')[-1]) for name in active_containers.keys()}
+                                    free_slot = next(i for i in range(len(slot_indices) + 1) if i not in slot_indices)
+                                    container_name = f"{VLLM_CONTAINER_PREFIX}_{free_slot}"
+                                    logging.info(f"Placing {target_model_id} on GPU {chosen_uuid} (pool '{pool}', "
+                                                 f"~{int(needed_est)} MiB); evicting {evictions or 'nothing'}; slot {container_name}.")
+
+                            # --- Evictions + start happen OUTSIDE the locks (I/O) ---
+                            for name in evictions:
                                 await stop_container(name)
 
-                            vram_before = await get_used_vram()
-                            logging.info(f"VRAM usage before model load: {vram_before} MiB")
+                            before_used = gpus_snapshot.get(chosen_uuid, {}).get("used", 0.0) if is_discovery else 0.0
 
-                            container_name = f"{VLLM_CONTAINER_PREFIX}_0"
-                            # Start container outside lock (long I/O operation)
-                            target_container = await start_model_container(target_model_id, container_name, model_cfg)
+                            try:
+                                target_container = await start_model_container(
+                                    target_model_id, container_name, model_cfg, gpu_uuids=[chosen_uuid])
+                                if target_container:
+                                    # Seed footprint with the estimate so concurrent placement counts this
+                                    # GPU as occupied immediately; discovery refines it just below.
+                                    target_container.vram_footprint = needed_est
+                                    async with model_management_lock:
+                                        active_containers[container_name] = target_container
+                            finally:
+                                # Always release the optimistic reservation (model is now resident-and-counted
+                                # on success, or never loaded on failure). Single source-of-truth invariant.
+                                async with placement_lock:
+                                    gpu_reservations[chosen_uuid] = max(0.0, gpu_reservations.get(chosen_uuid, 0.0) - needed_est)
 
-                            if target_container:
-                                # Wait for model to fully load into VRAM and take multiple measurements
-                                logging.info("Waiting for model to fully load into VRAM (taking 3 measurements over 45 seconds)...")
-                                await asyncio.sleep(15)
-                                vram_samples = [await get_used_vram()]
-
-                                await asyncio.sleep(15)
-                                vram_samples.append(await get_used_vram())
-
-                                await asyncio.sleep(15)
-                                vram_samples.append(await get_used_vram())
-
-                                # Use maximum VRAM measurement to ensure we capture full footprint
-                                vram_after = max(vram_samples)
-                                logging.info(f"VRAM samples: {vram_samples} MiB, using max: {vram_after} MiB")
-
-                                measured_vram = vram_after - vram_before
-
-                                if measured_vram > 256: # Sanity check for a reasonable footprint
-                                    logging.info(f"Measured VRAM footprint for {target_model_id}: {measured_vram} MiB")
-                                    target_container.vram_footprint = measured_vram
-                                    known_footprints[target_model_id] = measured_vram
-                                    save_known_footprints()
+                            # Discovery: measure the real footprint on the CHOSEN GPU only.
+                            if target_container and is_discovery:
+                                logging.info("Discovery: sampling chosen-GPU VRAM 3x over 45s...")
+                                samples = []
+                                for _ in range(3):
+                                    await asyncio.sleep(15)
+                                    samples.append((await get_gpu_vram()).get(chosen_uuid, {}).get("used", 0.0))
+                                measured = max(samples) - before_used
+                                if measured > 256:
+                                    logging.info(f"Measured VRAM footprint for {target_model_id} on {chosen_uuid}: {measured} MiB")
+                                    target_container.vram_footprint = measured
+                                    known_footprints[target_model_id] = measured
                                 else:
-                                    logging.warning(f"Could not measure accurate footprint for {target_model_id} (calculated {measured_vram} MiB). Using container without VRAM management.")
-                                    target_container.vram_footprint = 0  # Mark as unknown
-                                    known_footprints[target_model_id] = 0  # sentinel: seen but unmeasurable — prevents repeat discovery runs
-                                    save_known_footprints()
-
-                                # Update active_containers with lock
-                                async with model_management_lock:
-                                    active_containers[container_name] = target_container
-
-
-                        elif TOTAL_GPU_VRAM > 0:
-                            # KNOWN FOOTPRINT RUN
-                            # Calculate VRAM and determine evictions with lock
-                            async with model_management_lock:
-                                current_vram_usage = sum(c.vram_footprint for c in active_containers.values())
-
-                                # Guarded LRU eviction: never evict always_on or in-flight models,
-                                # prefer models past the anti-thrash cooldown (see placement.select_evictions).
-                                containers_to_evict = placement.select_evictions(
-                                    residents=list(active_containers.values()),
-                                    needed=footprint,
-                                    total_vram=TOTAL_GPU_VRAM,
-                                    current_usage=current_vram_usage,
-                                    now=time.time(),
-                                    min_resident_seconds=GATEWAY_MIN_RESIDENT_SECONDS,
-                                )
-                                if containers_to_evict:
-                                    freed = sum(active_containers[n].vram_footprint for n in containers_to_evict)
-                                    logging.info(f"Not enough VRAM for {target_model_id} (needs {footprint} MiB). "
-                                                 f"Evicting {len(containers_to_evict)} idle container(s) to free ~{freed} MiB: {containers_to_evict}")
-                                    if current_vram_usage - freed + footprint > TOTAL_GPU_VRAM:
-                                        logging.warning(f"Could not free enough VRAM for {target_model_id} without evicting "
-                                                        f"always_on/in-flight models; starting best-effort (may contend for VRAM).")
-
-                                # Find a free slot index
-                                slot_indices = {int(name.split('_')[-1]) for name in active_containers.keys()}
-                                free_slot = next(i for i in range(len(slot_indices) + 1) if i not in slot_indices)
-                                container_name = f"{VLLM_CONTAINER_PREFIX}_{free_slot}"
-
-                            # Evict containers outside lock (I/O operation)
-                            for name in containers_to_evict:
-                                await stop_container(name)
-
-                            # Start container outside lock (long I/O operation)
-                            target_container = await start_model_container(target_model_id, container_name, model_cfg)
-                            if target_container:
-                                target_container.vram_footprint = footprint
-                                # Update active_containers with lock
-                                async with model_management_lock:
-                                    active_containers[container_name] = target_container
-
+                                    logging.warning(f"Could not measure footprint for {target_model_id} ({measured} MiB); "
+                                                    f"keeping whole-card estimate {int(needed_est)} MiB.")
+                                    known_footprints[target_model_id] = 0  # sentinel: seen but unmeasurable
+                                save_known_footprints()
 
                         else: # Fallback if VRAM management is disabled
                             # Without VRAM management, only run one container at a time

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -21,12 +21,13 @@ ALLOWED_CONFIG_KEYS = {
     "inactivity_timeout",
     "always_on",
     "extra_args",
+    "pool",  # name of the GPU pool this model is placed in (multi-GPU); None = default pool
 }
 
 # Per-model entries additionally require/allow "repo".
 ALLOWED_MODEL_KEYS = ALLOWED_CONFIG_KEYS | {"repo"}
 
-ALLOWED_TOP_LEVEL_KEYS = {"defaults", "models"}
+ALLOWED_TOP_LEVEL_KEYS = {"defaults", "models", "pools"}
 
 
 @dataclass
@@ -42,6 +43,7 @@ class ModelConfig:
     inactivity_timeout: int
     always_on: bool
     extra_args: list
+    pool: Optional[str]  # GPU pool name (multi-GPU placement); None = the default/implicit pool
 
 
 def _require_int(field: str, model: str, value):
@@ -89,6 +91,10 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
     if not isinstance(extra_args, list):
         raise ValueError(f"model '{name}': 'extra_args' must be a list, got {extra_args!r}")
 
+    pool = merged["pool"]
+    if pool is not None and (not isinstance(pool, str) or not pool.strip()):
+        raise ValueError(f"model '{name}': 'pool' must be a non-empty string or null, got {pool!r}")
+
     return ModelConfig(
         name=name,
         repo=repo,
@@ -101,6 +107,7 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
         always_on=always_on,
         # Fresh list of strings; never share the builtins/defaults list across models.
         extra_args=[str(a) for a in extra_args],
+        pool=pool.strip() if isinstance(pool, str) else None,
     )
 
 
@@ -169,3 +176,51 @@ def build_fallback_configs(allowed_models: dict, builtins: dict) -> "dict[str, M
     for name, repo in allowed_models.items():
         out[name] = _construct(name, repo, dict(builtins))
     return out
+
+
+def resolve_pools(raw: dict) -> "dict[str, list]":
+    """Parse and validate the optional top-level ``pools`` section.
+
+    Returns {pool_name: [gpu_uuid, ...]}, or {} when no ``pools`` key is present
+    (single-pool / backward-compatible mode). Raises ValueError (fail fast) on a
+    malformed declaration so the gateway never starts with an ambiguous GPU topology.
+    """
+    if not isinstance(raw, dict) or "pools" not in raw:
+        return {}
+
+    pools = raw["pools"]
+    if not isinstance(pools, dict) or not pools:
+        raise ValueError("'pools' must be a non-empty mapping of pool-name -> [gpu-uuid, ...]")
+
+    seen = {}  # uuid -> pool name, to catch a UUID assigned to two pools
+    resolved: "dict[str, list]" = {}
+    for pool_name, uuids in pools.items():
+        if not isinstance(uuids, list) or not uuids:
+            raise ValueError(f"pool '{pool_name}' must be a non-empty list of GPU UUIDs")
+        clean = []
+        for u in uuids:
+            if not isinstance(u, str) or not u.strip():
+                raise ValueError(f"pool '{pool_name}' contains an invalid GPU UUID: {u!r}")
+            u = u.strip()
+            if u in seen:
+                raise ValueError(f"GPU UUID {u!r} is in both pools '{seen[u]}' and '{pool_name}'")
+            seen[u] = pool_name
+            clean.append(u)
+        resolved[pool_name] = clean
+    return resolved
+
+
+def validate_model_pools(configs: "dict[str, ModelConfig]", pools: "dict[str, list]") -> None:
+    """Ensure each model's resolved pool names a declared pool. Raises ValueError on mismatch.
+
+    When ``pools`` is empty (no multi-GPU topology), a stray per-model ``pool`` is meaningless
+    and ignored by the caller; we don't raise so adding ``pool:`` can't break the fallback path.
+    """
+    if not pools:
+        return
+    declared = set(pools)
+    for name, cfg in configs.items():
+        if cfg.pool is not None and cfg.pool not in declared:
+            raise ValueError(
+                f"model '{name}': pool '{cfg.pool}' is not a declared pool; declared: {sorted(declared)}"
+            )

--- a/gateway/placement.py
+++ b/gateway/placement.py
@@ -5,6 +5,29 @@ daemon (importing app.py triggers docker.from_env()). Functions operate on any o
 exposing the ContainerState attributes used below (duck-typed).
 """
 
+from dataclasses import dataclass
+
+
+@dataclass
+class GpuView:
+    """A point-in-time view of one GPU's VRAM for a placement decision (all MiB).
+
+    - used_smi: actual used VRAM from nvidia-smi (includes external processes such as an
+      out-of-band embedder, plus gateway models already visible to the driver).
+    - reserved: optimistic reservation for gateway models still loading (not yet smi-visible).
+    - ready_footprint: sum of known footprints of ready gateway models on this GPU; floors
+      `used_smi` so a just-loaded model isn't under-counted while nvidia-smi catches up.
+    """
+    uuid: str
+    total: float
+    used_smi: float = 0.0
+    reserved: float = 0.0
+    ready_footprint: float = 0.0
+
+    @property
+    def free(self) -> float:
+        return self.total - max(self.used_smi, self.ready_footprint) - self.reserved
+
 
 def _evictable_lru(residents, now, min_resident_seconds, allow_fresh):
     """Eviction candidates, least-recently-used first.
@@ -50,3 +73,51 @@ def select_evictions(residents, needed, total_vram, current_usage, now, min_resi
                 return chosen
         best = chosen  # remember the most we could free (widest set is the allow_fresh pass)
     return best
+
+
+def select_gpu(candidates, residents_by_gpu, needed, now, min_resident_seconds):
+    """Choose a GPU in a pool for a model needing `needed` MiB (whole-card, no TP).
+
+    candidates       : list[GpuView] — the pool's GPUs.
+    residents_by_gpu : {uuid: [resident, ...]} — gateway containers currently on each GPU.
+
+    Returns (chosen_uuid, eviction_container_names). chosen_uuid is None when no GPU can fit
+    the model even after evicting every idle/non-always_on model (remaining VRAM is held by
+    always_on or in-flight models, or external processes) — the caller should reject (503)
+    rather than over-commit and risk an OOM.
+
+    1. Direct fit: among GPUs with free >= needed, pick the MOST free (spreads load).
+    2. Otherwise, for each GPU compute a guarded LRU eviction set (select_evictions, scoped to
+       that GPU) and accept it only if it actually frees enough. Choose the GPU needing the
+       fewest evictions, tie-broken by most resulting free space.
+    """
+    # 1. Direct fit, most-free first.
+    direct = [g for g in candidates if g.free >= needed]
+    if direct:
+        best = max(direct, key=lambda g: g.free)
+        return best.uuid, []
+
+    # 2. Eviction required — evaluate each GPU.
+    options = []  # (num_evictions, -resulting_free, uuid, eviction_names)
+    for g in candidates:
+        residents = residents_by_gpu.get(g.uuid, [])
+        used_eff = g.total - g.free  # effective used (smi/floor + reservation)
+        evictions = select_evictions(
+            residents=residents,
+            needed=needed,
+            total_vram=g.total,
+            current_usage=used_eff,
+            now=now,
+            min_resident_seconds=min_resident_seconds,
+        )
+        footprint = {r.container_name: r.vram_footprint for r in residents}
+        freed = sum(footprint.get(n, 0.0) for n in evictions)
+        if g.free + freed >= needed:  # only accept GPUs that genuinely fit after eviction
+            resulting_free = g.free + freed
+            options.append((len(evictions), -resulting_free, g.uuid, evictions))
+
+    if not options:
+        return None, []
+    options.sort()
+    _, _, uuid, evictions = options[0]
+    return uuid, evictions

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -11,7 +11,9 @@ import sys
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
-from config_loader import resolve_model_configs, build_fallback_configs  # noqa: E402
+from config_loader import (  # noqa: E402
+    resolve_model_configs, build_fallback_configs, resolve_pools, validate_model_pools,
+)
 
 # Mirrors app.builtin_model_defaults() with stock env-var defaults.
 BUILTINS = {
@@ -23,6 +25,7 @@ BUILTINS = {
     "inactivity_timeout": 1800,
     "always_on": False,
     "extra_args": [],
+    "pool": None,
 }
 
 
@@ -136,6 +139,61 @@ def test_fallback_matches_builtins():
     assert c.inactivity_timeout == 1800
     assert c.always_on is False
     print("ok: fallback configs match builtins")
+
+
+# --- pools (multi-GPU) ---
+
+def test_resolve_pools_absent_and_valid():
+    assert resolve_pools({"models": {}}) == {}
+    pools = resolve_pools({"pools": {"llm": ["GPU-a", "GPU-b"], "util": ["GPU-c"]}, "models": {}})
+    assert pools == {"llm": ["GPU-a", "GPU-b"], "util": ["GPU-c"]}
+    print("ok: resolve_pools absent + valid")
+
+
+def test_resolve_pools_errors():
+    for raw, needle in [
+        ({"pools": {}}, "non-empty"),
+        ({"pools": {"llm": []}}, "non-empty list"),
+        ({"pools": {"llm": ["GPU-a", "  "]}}, "invalid GPU UUID"),
+        ({"pools": {"llm": ["GPU-a"], "util": ["GPU-a"]}}, "both pools"),
+    ]:
+        try:
+            resolve_pools(raw)
+        except ValueError as e:
+            assert needle in str(e), f"{needle!r} not in {e}"
+        else:
+            raise AssertionError(f"expected ValueError containing {needle!r}")
+    print("ok: resolve_pools errors")
+
+
+def test_pool_precedence_and_field():
+    raw = {
+        "defaults": {"pool": "llm"},
+        "models": {
+            "a": {"repo": "o/a"},                 # inherits defaults.pool
+            "b": {"repo": "o/b", "pool": "util"}, # per-model overrides
+        },
+    }
+    cfgs = resolve_model_configs(raw, BUILTINS)
+    assert cfgs["a"].pool == "llm"
+    assert cfgs["b"].pool == "util"
+    print("ok: pool precedence + field")
+
+
+def test_validate_model_pools():
+    pools = {"llm": ["GPU-a"], "util": ["GPU-b"]}
+    cfgs = resolve_model_configs({"models": {"a": {"repo": "o/a", "pool": "llm"}}}, BUILTINS)
+    validate_model_pools(cfgs, pools)  # ok
+    bad = resolve_model_configs({"models": {"a": {"repo": "o/a", "pool": "nope"}}}, BUILTINS)
+    try:
+        validate_model_pools(bad, pools)
+    except ValueError as e:
+        assert "not a declared pool" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for undeclared pool")
+    # pool set but no pools declared -> ignored (no raise)
+    validate_model_pools(bad, {})
+    print("ok: validate_model_pools")
 
 
 if __name__ == "__main__":

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
-from placement import select_evictions  # noqa: E402
+from placement import select_evictions, select_gpu, GpuView  # noqa: E402
 
 
 @dataclass
@@ -92,6 +92,57 @@ def test_best_effort_when_cannot_fit():
                            current_usage=22000, now=NOW, min_resident_seconds=90)
     # Best effort: evict what we can (the small one); caller logs/starts best-effort.
     assert out == ["small"], out
+
+
+# --- select_gpu (multi-GPU placement) ---
+
+def test_gpuview_free_floors_used_by_ready_footprint():
+    # A just-loaded model not yet in nvidia-smi: ready_footprint floors used_smi.
+    g = GpuView("A", total=24000, used_smi=500, reserved=0, ready_footprint=20000)
+    assert g.free == 24000 - 20000  # floored by ready_footprint, not the lagging 500
+    g2 = GpuView("B", total=24000, used_smi=21000, reserved=1000, ready_footprint=0)
+    assert g2.free == 24000 - 21000 - 1000
+
+
+def test_select_gpu_direct_fit_picks_most_free():
+    a = GpuView("A", total=24000, used_smi=10000)   # free 14000
+    b = GpuView("B", total=24000, used_smi=2000)     # free 22000
+    chosen, ev = select_gpu([a, b], {"A": [], "B": []}, needed=8000, now=NOW, min_resident_seconds=90)
+    assert chosen == "B" and ev == [], (chosen, ev)
+
+
+def test_select_gpu_external_process_excludes_gpu():
+    # A2000 (small, busy with an external embedder) can't fit; 3090 can.
+    a2000 = GpuView("A2000", total=6000, used_smi=4000)   # free 2000
+    rtx = GpuView("3090", total=24000, used_smi=0)        # free 24000
+    chosen, ev = select_gpu([a2000, rtx], {"A2000": [], "3090": []}, needed=8000, now=NOW, min_resident_seconds=90)
+    assert chosen == "3090" and ev == []
+
+
+def test_select_gpu_evicts_when_needed():
+    # GPU full with one old idle resident; eviction frees enough.
+    g = GpuView("A", total=24000, used_smi=20000, ready_footprint=20000)
+    resident = R("old", vram_footprint=20000, last_request_time=OLD, loaded_at=OLD)
+    chosen, ev = select_gpu([g], {"A": [resident]}, needed=18000, now=NOW, min_resident_seconds=90)
+    assert chosen == "A" and ev == ["old"], (chosen, ev)
+
+
+def test_select_gpu_no_fit_returns_none():
+    # Only resident is always_on and occupies the card -> cannot fit -> None (caller 503s).
+    g = GpuView("A", total=24000, used_smi=22000, ready_footprint=22000)
+    pinned = R("pinned", vram_footprint=22000, last_request_time=OLD, loaded_at=OLD, always_on=True)
+    chosen, ev = select_gpu([g], {"A": [pinned]}, needed=8000, now=NOW, min_resident_seconds=90)
+    assert chosen is None and ev == [], (chosen, ev)
+
+
+def test_select_gpu_prefers_fewer_evictions():
+    # Two GPUs can fit after eviction; pick the one needing fewer evictions.
+    g1 = GpuView("G1", total=24000, used_smi=24000, ready_footprint=24000)  # needs 2 evictions
+    g1r = [R("g1a", 12000, OLD, loaded_at=OLD), R("g1b", 12000, OLD - 1, loaded_at=OLD)]
+    g2 = GpuView("G2", total=24000, used_smi=24000, ready_footprint=24000)  # needs 1 eviction
+    g2r = [R("g2a", 24000, OLD, loaded_at=OLD)]
+    chosen, ev = select_gpu([g1, g2], {"G1": g1r, "G2": g2r}, needed=20000, now=NOW, min_resident_seconds=90)
+    assert chosen == "G2" and ev == ["g2a"], (chosen, ev)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #4 (base branch `placement-phase-1a`) — this PR shows only the Phase 1b diff.
Merge #4 first, then retarget this to `master` (or merge in order).

## What

One gateway can now manage several GPUs via **configurable pools**, assigning a specific GPU
per request. Bounded scope per the agreed plan: **whole-card model — no tensor-parallel, no
co-location** (each model gets ~its whole GPU at its `gpu_memory_utilization`). Decided with the
maintainer: embeddings run **out-of-band** on the A2000 (separate TEI/infinity), not through the gateway.

## Changes

- **`config_loader.py`** — optional top-level `pools:` + per-model `pool:`; `ModelConfig.pool`;
  `resolve_pools()` + `validate_model_pools()` (fail-fast if a model names an undeclared pool).
  `resolve_model_configs` signature unchanged (existing tests stable).
- **`placement.py`** — `GpuView` (`free = total − max(used_smi, ready_footprint) − reserved`; the
  `ready_footprint` floor closes the nvidia-smi lag window) and `select_gpu()` (direct-fit most-free
  → per-GPU guarded LRU eviction → `None` when nothing fits). Reuses `select_evictions` unchanged.
- **`app.py`** — `placement_lock` + per-GPU `gpu_reservations` + `MANAGED_POOLS/GPUS`;
  `resolve_managed_pools()` at startup (precedence `pools:` → `GATEWAY_GPU_UUID` → all-visible);
  `start_model_container(gpu_uuids=…)` builds `device_requests` dynamically; the nvidia-smi probe
  sees all managed GPUs; `ContainerState.gpu_uuids`. Placement reworked: snapshot VRAM **outside**
  the lock → decide+reserve **under** `placement_lock` → evict+start **outside** → free reservation
  in `finally` (leak guard) → discovery measured on the **chosen GPU only**. `/gateway/status` adds
  per-GPU `{pool, total, used, reserved, residents}`.
- **Docs/config** — `models.yaml.example` gains `pools:`/`pool:` + a util-pool model and drops the
  embedders; README "Multi-GPU pools" section; compose comment updated.

## Backward compatibility

No `pools:` → single pool (the `GATEWAY_GPU_UUID` pin if set, else all visible GPUs) — unchanged.
`ALLOWED_MODELS_JSON` fallback unchanged.

## Behavioral change to flag

No-fit now returns **503** instead of silently over-committing — only triggers when a pool's spare
VRAM is held entirely by `always_on`/in-flight models (a case that would OOM today), so it's strictly
safer but observable.

## Test plan

- `python3 -c "import ast; ast.parse(open('gateway/app.py').read())"` — passes.
- `tests/test_placement.py` — 13/13 (incl. `select_gpu` most-free, external-process exclusion,
  evict-when-needed, no-fit→`None`, fewest-evictions, `ready_footprint` floor).
- `tests/test_config_resolution.py` — 9/9 (pools valid/error/precedence/validate + all prior).
- Docker-stubbed import smoke: pool-resolution precedence + fail-fast on undeclared pool.
- **Not yet run on real multi-GPU hardware / a live Docker daemon** — integration items (real device
  pinning, concurrent eviction serialization, reservation-leak-on-failure) need the 3090+A2000 box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)