### PR TITLE
Tensor parallel (Phase 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,8 +174,15 @@ models:
   `always_on` or in-flight) on a pool GPU; if it still can't fit, it returns **503** (it never
   over-commits and risks an OOM). Per-GPU accounting uses *actual* free VRAM from `nvidia-smi`, so
   it tolerates VRAM used by processes the gateway didn't start.
-- **Whole-card model.** This release does **not** tensor-parallel or co-locate multiple models on
-  one card — each model gets ~its whole GPU at its `gpu_memory_utilization`.
+- **Tensor parallel.** Set `tensor_parallel_size: k` to spread one model across `k` GPUs of its
+  pool (launched with `--tensor-parallel-size k`, pinned to those cards). TP requires a
+  **homogeneous** pool (equal-VRAM GPUs — never a 3090+A2000 mix; the util pool's single A2000
+  never TPs) and `k` must not exceed the GPUs declared in the pool (validated at startup). A model
+  with `tensor_parallel_size: 1` whose **weights exceed one card** auto-falls-back to the minimal TP
+  that fits. TP over PCIe (no NVLink) has real comms cost, so prefer single-GPU when a model fits.
+  Each card is still filled to `gpu_memory_utilization` (TP fits bigger *weights*, not more KV).
+- **No co-location.** This release does not co-locate multiple models on one card — each model gets
+  ~its whole GPU at its `gpu_memory_utilization`.
 - **GPU source precedence.** `pools:` in config → else `GATEWAY_GPU_UUID` (a single-GPU pool) →
   else all visible GPUs (the legacy single-pool behavior). When no `pools:` are declared, behavior
   is unchanged.

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -13,15 +13,20 @@
 # full UUIDs from `nvidia-smi -L`. A model is placed on a GPU within its pool.
 #   - If 'pools' is omitted, the gateway runs single-pool: the GATEWAY_GPU_UUID
 #     pin if set, else all visible GPUs (unchanged legacy behavior).
-#   - Tensor-parallel and multi-model co-location are not yet supported: each model
-#     gets ~its whole GPU at its gpu_memory_utilization (whole-card placement).
+#   - Each model gets ~its whole GPU at its gpu_memory_utilization (whole-card
+#     placement); multi-model co-location is not yet supported.
+#   - Tensor-parallel (tensor_parallel_size > 1) spreads ONE model across several
+#     GPUs of its pool. TP requires a HOMOGENEOUS pool (equal-VRAM cards) — never
+#     mix a 3090 and an A2000. TP over PCIe (no NVLink) has real comms cost, so use
+#     it only for models that genuinely won't fit on one card.
 # NOTE: Embeddings/rerankers are expected to run OUT OF BAND — a separate always-on
 # TEI/infinity container pinned to the A2000 — NOT through this gateway. They are
 # therefore intentionally absent below. The gateway's 'util' pool reads the A2000's
 # real free VRAM (via nvidia-smi), so it accounts for that external embedder.
 pools:
-  llm:                                   # RTX 3090 — LLMs
+  llm:                                   # RTX 3090s (homogeneous) — LLMs; TP-capable
     - GPU-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+    - GPU-zzzzzzzz-zzzz-zzzz-zzzz-zzzzzzzzzzzz
   util:                                  # RTX A2000 — small/utility models (shares card with embedder)
     - GPU-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
 
@@ -59,3 +64,13 @@ models:                        # required, non-empty
     repo: Qwen/Qwen2.5-3B-Instruct
     pool: util
     gpu_memory_utilization: 0.45   # leave headroom for the external embedder on the A2000
+
+  # A large model forced across both 3090s with tensor parallel. tensor_parallel_size must
+  # not exceed the GPUs declared in the pool (validated at startup), and the pool must be
+  # homogeneous (checked at placement). Models that fit on one card stay single-GPU; a model
+  # too big for one card auto-falls-back to the minimal TP that fits even without this flag.
+  big-llm-tp2:
+    repo: cyankiwi/Qwen3.5-27B-AWQ-4bit
+    quantization: awq
+    pool: llm
+    tensor_parallel_size: 2

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -18,7 +18,7 @@ import yaml
 import placement
 from config_loader import (
     ModelConfig, resolve_model_configs, build_fallback_configs,
-    resolve_pools, validate_model_pools,
+    resolve_pools, validate_model_pools, validate_tp_against_pools,
 )
 
 # --- Logging Configuration ---
@@ -560,6 +560,7 @@ def load_model_configs() -> "tuple[dict, dict]":
         configs = resolve_model_configs(raw, builtins)
         pools = resolve_pools(raw)
         validate_model_pools(configs, pools)  # fail fast on a model referencing an undeclared pool
+        validate_tp_against_pools(configs, pools)  # fail fast if tensor_parallel_size > pool GPU count
         logging.info(f"Loaded {len(configs)} model(s) from {MODELS_CONFIG_FILE}: {list(configs)}")
         if pools:
             logging.info(f"Declared GPU pools: { {p: len(u) for p, u in pools.items()} }")
@@ -678,6 +679,26 @@ async def get_model_max_len(model_id: str) -> int:
         logging.error(f"An error occurred while getting max length for {model_id}: {e}")
         return 0
 
+async def estimate_weight_bytes(model_id: str) -> "int | None":
+    """Best-effort estimate of a model's on-disk weight size in bytes, for the TP-fallback
+    decision (how many GPUs a model's weights need). Returns None when it can't be determined.
+
+    Reads the safetensors shard index (one small JSON GET, same pattern as get_model_max_len);
+    that metadata already reflects quantized sizes. GGUF / non-safetensors repos return None,
+    in which case the caller degrades to the configured tensor_parallel_size."""
+    if is_gguf_model(model_id) or '/' not in model_id or model_id.startswith(('http://', 'https://')):
+        return None
+    index_url = f"https://huggingface.co/{model_id}/raw/main/model.safetensors.index.json"
+    try:
+        resp = await http_client.get(index_url, follow_redirects=True, timeout=httpx.Timeout(10.0))
+        if resp.status_code == 200:
+            total = resp.json().get("metadata", {}).get("total_size")
+            if isinstance(total, int) and total > 0:
+                return total
+    except Exception as e:
+        logging.warning(f"Could not estimate weight size for {model_id}: {e}")
+    return None
+
 def merge_extra_args(base: "list[str]", extra: "list[str]") -> "list[str]":
     """Append raw extra_args verbatim, letting them override any flag the base set.
 
@@ -707,11 +728,15 @@ def merge_extra_args(base: "list[str]", extra: "list[str]") -> "list[str]":
     return merged
 
 async def start_model_container(model_id: str, container_name: str, model_cfg: ModelConfig,
-                                gpu_uuids: "list[str] | None" = None) -> ContainerState | None:
+                                gpu_uuids: "list[str] | None" = None,
+                                effective_tp: "int | None" = None) -> ContainerState | None:
     """Starts a new vLLM container using the model's resolved configuration.
 
     gpu_uuids pins the container to specific GPU(s) (multi-GPU placement). When None/empty,
-    falls back to GPU_DEVICE_REQUESTS (the gateway-wide pin or all GPUs) for backward compat."""
+    falls back to GPU_DEVICE_REQUESTS (the gateway-wide pin or all GPUs) for backward compat.
+    effective_tp overrides --tensor-parallel-size (for TP fallback); defaults to the model's
+    configured tensor_parallel_size. model_cfg is never mutated (it is shared across requests)."""
+    tp = effective_tp if effective_tp else model_cfg.tensor_parallel_size
     logging.info(f"Attempting to start model {model_id} in container {container_name}")
 
     # Clean up any existing container with the same name (from crashes or improper shutdowns)
@@ -791,8 +816,8 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
     # Always present: --model, --gpu-memory-utilization, --tensor-parallel-size.
     command = ["--model", actual_model_path,
                "--gpu-memory-utilization", str(model_cfg.gpu_memory_utilization)]
-    if model_cfg.tensor_parallel_size > 0:
-        command.extend(["--tensor-parallel-size", str(model_cfg.tensor_parallel_size)])
+    if tp > 0:
+        command.extend(["--tensor-parallel-size", str(tp)])
 
     # Add GGUF-specific parameters if this is a GGUF model
     if is_gguf_model(actual_model_path) or tokenizer_repo:
@@ -1111,7 +1136,27 @@ async def proxy_request(request: Request):
                             # Snapshot per-GPU VRAM OUTSIDE the placement lock (it spawns a container).
                             gpus_snapshot = await get_gpu_vram()
 
-                            # --- DECIDE: choose a GPU + reserve, under the global placement lock ---
+                            # Per-card need (whole-card model: independent of TP degree).
+                            if footprint and footprint > 0:
+                                needed_per_gpu = float(footprint)
+                            else:
+                                pool_totals = [float(gpus_snapshot.get(u, {}).get("total", 0.0)) for u in pool_gpus]
+                                needed_per_gpu = model_cfg.gpu_memory_utilization * (max(pool_totals) if pool_totals else 0.0)
+
+                            # Effective TP: forced by config, or auto-fallback for an unseen model whose
+                            # weights exceed one card (only in a homogeneous, multi-GPU pool).
+                            effective_tp = model_cfg.tensor_parallel_size
+                            if (is_discovery and model_cfg.tensor_parallel_size == 1 and len(pool_gpus) >= 2):
+                                pool_totals = [float(gpus_snapshot.get(u, {}).get("total", 0.0)) for u in pool_gpus]
+                                if pool_totals and (max(pool_totals) - min(pool_totals)) <= 0.05 * max(pool_totals):
+                                    wbytes = await estimate_weight_bytes(target_model_id)
+                                    min_tp = placement.minimal_tp_to_fit(
+                                        wbytes, max(pool_totals), model_cfg.gpu_memory_utilization, pool_size=len(pool_gpus))
+                                    if min_tp > effective_tp:
+                                        logging.info(f"TP fallback for {target_model_id}: weights ~{wbytes} B -> tp={min_tp}")
+                                        effective_tp = min_tp
+
+                            # --- DECIDE: choose GPU(s) + reserve, under the global placement lock ---
                             async with model_management_lock:
                                 async with placement_lock:
                                     candidates = []
@@ -1127,66 +1172,65 @@ async def proxy_request(request: Request):
                                             reserved=gpu_reservations.get(guid, 0.0),
                                             ready_footprint=sum(c.vram_footprint for c in residents),
                                         ))
-                                    # Whole-card estimate when the footprint isn't a measured number.
-                                    if footprint and footprint > 0:
-                                        needed_est = float(footprint)
-                                    else:
-                                        max_total = max((c.total for c in candidates), default=0.0)
-                                        needed_est = model_cfg.gpu_memory_utilization * max_total
 
-                                    chosen_uuid, evictions = placement.select_gpu(
-                                        candidates, residents_by_gpu, needed_est,
+                                    chosen_uuids, evictions = placement.select_placement(
+                                        candidates, residents_by_gpu, needed_per_gpu, effective_tp,
                                         time.time(), GATEWAY_MIN_RESIDENT_SECONDS,
                                     )
-                                    if chosen_uuid is None:
+                                    if chosen_uuids is None:
                                         raise HTTPException(
                                             status_code=503,
-                                            detail=(f"No GPU in pool '{pool}' can fit model {target_model_id} "
-                                                    f"(~{int(needed_est)} MiB) without evicting always_on/in-flight models. Retry later."))
+                                            detail=(f"Cannot place model {target_model_id} in pool '{pool}' at tp={effective_tp} "
+                                                    f"(~{int(needed_per_gpu)} MiB/GPU): pool not homogeneous, has too few GPUs, "
+                                                    f"or no {effective_tp} GPU(s) free without evicting always_on/in-flight models. Retry later."))
 
-                                    gpu_reservations[chosen_uuid] = gpu_reservations.get(chosen_uuid, 0.0) + needed_est
+                                    for u in chosen_uuids:
+                                        gpu_reservations[u] = gpu_reservations.get(u, 0.0) + needed_per_gpu
                                     slot_indices = {int(name.split('_')[-1]) for name in active_containers.keys()}
                                     free_slot = next(i for i in range(len(slot_indices) + 1) if i not in slot_indices)
                                     container_name = f"{VLLM_CONTAINER_PREFIX}_{free_slot}"
-                                    logging.info(f"Placing {target_model_id} on GPU {chosen_uuid} (pool '{pool}', "
-                                                 f"~{int(needed_est)} MiB); evicting {evictions or 'nothing'}; slot {container_name}.")
+                                    logging.info(f"Placing {target_model_id} on GPU(s) {chosen_uuids} (pool '{pool}', tp={effective_tp}, "
+                                                 f"~{int(needed_per_gpu)} MiB/GPU); evicting {evictions or 'nothing'}; slot {container_name}.")
 
                             # --- Evictions + start happen OUTSIDE the locks (I/O) ---
                             for name in evictions:
                                 await stop_container(name)
 
-                            before_used = gpus_snapshot.get(chosen_uuid, {}).get("used", 0.0) if is_discovery else 0.0
+                            before_used = gpus_snapshot.get(chosen_uuids[0], {}).get("used", 0.0) if is_discovery else 0.0
 
                             try:
                                 target_container = await start_model_container(
-                                    target_model_id, container_name, model_cfg, gpu_uuids=[chosen_uuid])
+                                    target_model_id, container_name, model_cfg,
+                                    gpu_uuids=chosen_uuids, effective_tp=effective_tp)
                                 if target_container:
-                                    # Seed footprint with the estimate so concurrent placement counts this
-                                    # GPU as occupied immediately; discovery refines it just below.
-                                    target_container.vram_footprint = needed_est
+                                    # Seed footprint with the estimate so concurrent placement counts these
+                                    # GPU(s) as occupied immediately; discovery refines it just below.
+                                    target_container.vram_footprint = needed_per_gpu
                                     async with model_management_lock:
                                         active_containers[container_name] = target_container
                             finally:
-                                # Always release the optimistic reservation (model is now resident-and-counted
-                                # on success, or never loaded on failure). Single source-of-truth invariant.
+                                # Always release the optimistic reservation on ALL chosen GPUs (model is now
+                                # resident-and-counted on success, or never loaded on failure).
                                 async with placement_lock:
-                                    gpu_reservations[chosen_uuid] = max(0.0, gpu_reservations.get(chosen_uuid, 0.0) - needed_est)
+                                    for u in chosen_uuids:
+                                        gpu_reservations[u] = max(0.0, gpu_reservations.get(u, 0.0) - needed_per_gpu)
 
-                            # Discovery: measure the real footprint on the CHOSEN GPU only.
+                            # Discovery: measure the per-GPU footprint on one chosen GPU (homogeneous + symmetric under TP).
                             if target_container and is_discovery:
-                                logging.info("Discovery: sampling chosen-GPU VRAM 3x over 45s...")
+                                meas_gpu = chosen_uuids[0]
+                                logging.info(f"Discovery: sampling GPU {meas_gpu} VRAM 3x over 45s...")
                                 samples = []
                                 for _ in range(3):
                                     await asyncio.sleep(15)
-                                    samples.append((await get_gpu_vram()).get(chosen_uuid, {}).get("used", 0.0))
+                                    samples.append((await get_gpu_vram()).get(meas_gpu, {}).get("used", 0.0))
                                 measured = max(samples) - before_used
                                 if measured > 256:
-                                    logging.info(f"Measured VRAM footprint for {target_model_id} on {chosen_uuid}: {measured} MiB")
+                                    logging.info(f"Measured per-GPU footprint for {target_model_id} on {meas_gpu}: {measured} MiB")
                                     target_container.vram_footprint = measured
                                     known_footprints[target_model_id] = measured
                                 else:
                                     logging.warning(f"Could not measure footprint for {target_model_id} ({measured} MiB); "
-                                                    f"keeping whole-card estimate {int(needed_est)} MiB.")
+                                                    f"keeping whole-card estimate {int(needed_per_gpu)} MiB.")
                                     known_footprints[target_model_id] = 0  # sentinel: seen but unmeasurable
                                 save_known_footprints()
 

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -215,12 +215,37 @@ def validate_model_pools(configs: "dict[str, ModelConfig]", pools: "dict[str, li
 
     When ``pools`` is empty (no multi-GPU topology), a stray per-model ``pool`` is meaningless
     and ignored by the caller; we don't raise so adding ``pool:`` can't break the fallback path.
+    When ``pools`` is declared, every model must name one (an explicit ``pool`` or a
+    ``defaults.pool``) — a pool-less model would otherwise have no GPUs to place onto.
     """
     if not pools:
         return
     declared = set(pools)
     for name, cfg in configs.items():
-        if cfg.pool is not None and cfg.pool not in declared:
+        if cfg.pool is None:
+            raise ValueError(
+                f"model '{name}': no pool set, but pools are declared. Set 'pool' on the model "
+                f"or a 'defaults.pool'; declared pools: {sorted(declared)}"
+            )
+        if cfg.pool not in declared:
             raise ValueError(
                 f"model '{name}': pool '{cfg.pool}' is not a declared pool; declared: {sorted(declared)}"
             )
+
+
+def validate_tp_against_pools(configs: "dict[str, ModelConfig]", pools: "dict[str, list]") -> None:
+    """Fail fast when a model's tensor_parallel_size exceeds the GPUs declared in its pool.
+
+    Only meaningful when ``pools`` is declared (the GPU count per pool is then known at load
+    time). Homogeneity (equal VRAM) can only be checked at runtime; placement enforces that.
+    """
+    if not pools:
+        return
+    for name, cfg in configs.items():
+        if cfg.tensor_parallel_size > 1 and cfg.pool in pools:
+            available = len(pools[cfg.pool])
+            if cfg.tensor_parallel_size > available:
+                raise ValueError(
+                    f"model '{name}': tensor_parallel_size={cfg.tensor_parallel_size} exceeds the "
+                    f"{available} GPU(s) declared in pool '{cfg.pool}'"
+                )

--- a/gateway/placement.py
+++ b/gateway/placement.py
@@ -5,6 +5,7 @@ daemon (importing app.py triggers docker.from_env()). Functions operate on any o
 exposing the ContainerState attributes used below (duck-typed).
 """
 
+import math
 from dataclasses import dataclass
 
 
@@ -121,3 +122,83 @@ def select_gpu(candidates, residents_by_gpu, needed, now, min_resident_seconds):
     options.sort()
     _, _, uuid, evictions = options[0]
     return uuid, evictions
+
+
+def _homogeneous(candidates, tol=0.05) -> bool:
+    """True iff all candidate GPUs have ~equal total VRAM (within `tol` of the largest).
+
+    Tensor-parallel requires equal-VRAM cards; this decisively rejects a mixed pool
+    (e.g. a 24 GB 3090 + a 6 GB A2000) while tolerating minor driver/ECC reporting drift."""
+    totals = [c.total for c in candidates]
+    if not totals:
+        return False
+    hi = max(totals)
+    return hi > 0 and (hi - min(totals)) <= tol * hi
+
+
+def minimal_tp_to_fit(weight_bytes, card_total_mib, util, overhead=1.2, pool_size=None) -> int:
+    """Minimal tensor-parallel degree so a model's weights fit across homogeneous cards.
+
+    weight_bytes : estimated total model weight size in bytes (None/0 -> 1, i.e. no split).
+    Per card, vLLM can use ~util*card_total_mib; `overhead` (~1.2) allows for activations /
+    CUDA context / fragmentation on top of raw weights. Result is capped at pool_size."""
+    if not weight_bytes or weight_bytes <= 0:
+        return 1
+    usable_per_card = util * card_total_mib
+    if usable_per_card <= 0:
+        return 1
+    weight_mib = (weight_bytes / (1024.0 * 1024.0)) * overhead
+    tp = max(1, math.ceil(weight_mib / usable_per_card))
+    if pool_size is not None:
+        tp = min(tp, pool_size)
+    return tp
+
+
+def _gpu_fit_cost(g, residents, needed, now, min_resident_seconds):
+    """Can GPU `g` host `needed` MiB? Returns (num_evictions, resulting_free, eviction_names)
+    if it can (directly or after guarded eviction), else None."""
+    if g.free >= needed:
+        return (0, g.free, [])
+    evictions = select_evictions(
+        residents=residents, needed=needed, total_vram=g.total,
+        current_usage=g.total - g.free, now=now, min_resident_seconds=min_resident_seconds,
+    )
+    footprint = {r.container_name: r.vram_footprint for r in residents}
+    freed = sum(footprint.get(n, 0.0) for n in evictions)
+    if g.free + freed >= needed:
+        return (len(evictions), g.free + freed, evictions)
+    return None
+
+
+def select_placement(candidates, residents_by_gpu, needed_per_gpu, tp, now, min_resident_seconds):
+    """Choose GPU(s) for a model. Returns (chosen_uuids: list | None, eviction_names: list).
+
+    tp == 1 : single-GPU placement (delegates to select_gpu — identical to Phase 1b).
+    tp >= 2 : tensor-parallel across exactly `tp` GPUs of a HOMOGENEOUS pool. Each chosen GPU
+              must host `needed_per_gpu` (vLLM applies gpu_memory_utilization to every card, so
+              the per-card need does NOT shrink with tp). Picks the `tp` GPUs needing the fewest
+              evictions (tie-break: most resulting free), evicting guarded-LRU per GPU. Returns
+              None if the pool is heterogeneous, has fewer than `tp` GPUs, or `tp` GPUs can't fit.
+    """
+    if tp <= 1:
+        uuid, evictions = select_gpu(candidates, residents_by_gpu, needed_per_gpu, now, min_resident_seconds)
+        return ([uuid], evictions) if uuid is not None else (None, [])
+
+    if not _homogeneous(candidates) or len(candidates) < tp:
+        return None, []
+
+    options = []  # (num_evictions, -resulting_free, uuid, eviction_names)
+    for g in candidates:
+        cost = _gpu_fit_cost(g, residents_by_gpu.get(g.uuid, []), needed_per_gpu, now, min_resident_seconds)
+        if cost is not None:
+            num_ev, resulting_free, ev = cost
+            options.append((num_ev, -resulting_free, g.uuid, ev))
+
+    if len(options) < tp:
+        return None, []
+    options.sort()
+    chosen = options[:tp]
+    chosen_uuids = [o[2] for o in chosen]
+    # Dedupe eviction names (a multi-GPU/TP resident can appear on several chosen GPUs).
+    evictions = list(dict.fromkeys(n for o in chosen for n in o[3]))
+    return chosen_uuids, evictions

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -12,7 +12,8 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
 from config_loader import (  # noqa: E402
-    resolve_model_configs, build_fallback_configs, resolve_pools, validate_model_pools,
+    resolve_model_configs, build_fallback_configs, resolve_pools,
+    validate_model_pools, validate_tp_against_pools,
 )
 
 # Mirrors app.builtin_model_defaults() with stock env-var defaults.
@@ -194,6 +195,39 @@ def test_validate_model_pools():
     # pool set but no pools declared -> ignored (no raise)
     validate_model_pools(bad, {})
     print("ok: validate_model_pools")
+
+
+def test_poolless_model_rejected_when_pools_declared():
+    pools = {"llm": ["GPU-a"]}
+    cfgs = resolve_model_configs({"models": {"a": {"repo": "o/a"}}}, BUILTINS)  # no pool, no default
+    try:
+        validate_model_pools(cfgs, pools)
+    except ValueError as e:
+        assert "no pool set" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for pool-less model under declared pools")
+    # but with a defaults.pool it resolves and passes
+    ok = resolve_model_configs({"defaults": {"pool": "llm"}, "models": {"a": {"repo": "o/a"}}}, BUILTINS)
+    validate_model_pools(ok, pools)
+    print("ok: pool-less model rejected when pools declared")
+
+
+def test_validate_tp_against_pools():
+    pools = {"llm": ["GPU-a", "GPU-b"], "util": ["GPU-c"]}
+    # tp=2 with 2-GPU pool -> ok
+    ok = resolve_model_configs({"models": {"m": {"repo": "o/m", "pool": "llm", "tensor_parallel_size": 2}}}, BUILTINS)
+    validate_tp_against_pools(ok, pools)
+    # tp=2 in a 1-GPU pool -> raises
+    bad = resolve_model_configs({"models": {"m": {"repo": "o/m", "pool": "util", "tensor_parallel_size": 2}}}, BUILTINS)
+    try:
+        validate_tp_against_pools(bad, pools)
+    except ValueError as e:
+        assert "exceeds" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for tp > pool size")
+    # no pools declared -> never raises on tp
+    validate_tp_against_pools(bad, {})
+    print("ok: validate_tp_against_pools")
 
 
 if __name__ == "__main__":

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -10,7 +10,9 @@ from dataclasses import dataclass
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
-from placement import select_evictions, select_gpu, GpuView  # noqa: E402
+from placement import (  # noqa: E402
+    select_evictions, select_gpu, GpuView, select_placement, minimal_tp_to_fit, _homogeneous,
+)
 
 
 @dataclass
@@ -143,6 +145,68 @@ def test_select_gpu_prefers_fewer_evictions():
     g2r = [R("g2a", 24000, OLD, loaded_at=OLD)]
     chosen, ev = select_gpu([g1, g2], {"G1": g1r, "G2": g2r}, needed=20000, now=NOW, min_resident_seconds=90)
     assert chosen == "G2" and ev == ["g2a"], (chosen, ev)
+
+
+# --- select_placement / TP (Phase 2) ---
+
+def test_homogeneous_helper():
+    assert _homogeneous([GpuView("A", 24000), GpuView("B", 24000)])
+    assert _homogeneous([GpuView("A", 24000), GpuView("B", 23500)])   # within 5%
+    assert not _homogeneous([GpuView("A", 24000), GpuView("B", 6000)])  # 3090 + A2000
+
+
+def test_minimal_tp_to_fit():
+    # weights fit one card -> 1
+    assert minimal_tp_to_fit(10 * 1024**3, 24000, 0.9) == 1
+    # ~30 GiB weights * 1.2 overhead = 36 GiB; usable/card = 0.9*24000 MiB ≈ 21.6 GiB -> 2
+    assert minimal_tp_to_fit(30 * 1024**3, 24000, 0.9) == 2
+    # huge weights capped at pool size
+    assert minimal_tp_to_fit(500 * 1024**3, 24000, 0.9, pool_size=2) == 2
+    # unknown size -> no split
+    assert minimal_tp_to_fit(None, 24000, 0.9) == 1
+    assert minimal_tp_to_fit(0, 24000, 0.9) == 1
+
+
+def test_select_placement_tp1_matches_select_gpu():
+    a = GpuView("A", 24000, used_smi=10000)
+    b = GpuView("B", 24000, used_smi=2000)
+    rbg = {"A": [], "B": []}
+    sp = select_placement([a, b], rbg, 8000, 1, NOW, 90)
+    sg = select_gpu([a, b], rbg, 8000, NOW, 90)
+    assert sp == ([sg[0]], sg[1]), (sp, sg)   # tp==1 wraps select_gpu identically
+
+
+def test_select_placement_forced_tp2_picks_two_most_free():
+    a = GpuView("A", 24000, used_smi=20000)  # free 4000
+    b = GpuView("B", 24000, used_smi=0)       # free 24000
+    c = GpuView("C", 24000, used_smi=1000)    # free 23000
+    chosen, ev = select_placement([a, b, c], {"A": [], "B": [], "C": []}, 8000, 2, NOW, 90)
+    assert sorted(chosen) == ["B", "C"] and ev == [], (chosen, ev)
+
+
+def test_select_placement_tp_rejects_heterogeneous():
+    a = GpuView("3090", 24000, used_smi=0)
+    b = GpuView("A2000", 6000, used_smi=0)
+    chosen, ev = select_placement([a, b], {"3090": [], "A2000": []}, 4000, 2, NOW, 90)
+    assert chosen is None, chosen
+
+
+def test_select_placement_tp_insufficient_gpus():
+    # forced tp=2 with only one GPU visible (2nd 3090 not installed) -> None, graceful
+    a = GpuView("A", 24000, used_smi=0)
+    chosen, ev = select_placement([a], {"A": []}, 8000, 2, NOW, 90)
+    assert chosen is None, chosen
+
+
+def test_select_placement_tp_evicts_and_dedupes():
+    # Both GPUs full; each has an idle resident; tp=2 must evict on both, deduped.
+    a = GpuView("A", 24000, used_smi=24000, ready_footprint=24000)
+    b = GpuView("B", 24000, used_smi=24000, ready_footprint=24000)
+    ra = [R("ra", 24000, OLD, loaded_at=OLD)]
+    rb = [R("rb", 24000, OLD, loaded_at=OLD)]
+    chosen, ev = select_placement([a, b], {"A": ra, "B": rb}, 20000, 2, NOW, 90)
+    assert sorted(chosen) == ["A", "B"]
+    assert sorted(ev) == ["ra", "rb"] and len(ev) == len(set(ev)), ev
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #5 (base `placement-phase-1b`) — shows only the Phase 2 diff. Merge #4 → #5 → this in order.

## What
Place a model across multiple GPUs of its pool:
- **Forced TP** — `tensor_parallel_size: k` (k≥2) runs the model across exactly `k` GPUs, pinned via `device_ids`, launched with `--tensor-parallel-size k`.
- **TP fallback** — an unseen `tensor_parallel_size: 1` model whose *weights* exceed one card auto-splits across the minimal homogeneous GPU count that fits (`effective_tp = max(configured, minimal_tp_to_fit)`).

Constraints (docs Part B): TP only across a **homogeneous** pool (equal-VRAM cards — never a 3090+A2000 mix; the single-GPU util pool never TPs). Whole-card model: vLLM fills each card to `gpu_memory_utilization`, so per-GPU need is independent of `k` — TP fits bigger *weights*, not more KV.

## Changes
- **`placement.py`** — `select_placement()` (tp==1 delegates to the unchanged `select_gpu`; tp≥2 = homogeneity gate + per-GPU guarded eviction + dedupe), `_homogeneous()`, `minimal_tp_to_fit()`. Pure/docker-free.
- **`config_loader.py`** — `validate_tp_against_pools()` (tp must not exceed declared pool GPUs — fail fast); `validate_model_pools()` now also rejects a pool-less model when pools are declared (closes a Phase 1b gap).
- **`app.py`** — `estimate_weight_bytes()` (safetensors index; degrades to `None` → configured tp); `effective_tp` decided before the placement lock; reservation **loop over all `k`** chosen GPUs (freed on every exit via `finally`); `start_model_container(gpu_uuids=list, effective_tp=)` without mutating the shared `model_cfg`; discovery measured on one chosen GPU. Heterogeneous / insufficient / no-fit → clear **503**; forced `tp=2` on a 1-GPU pool **fails fast at startup** (never crashes).

## Backward compatibility
`tp==1` with no fallback is byte-identical to Phase 1b. No-pools / single-GPU paths unchanged.

## Test plan
- `ast.parse` on all three modules — passes.
- `tests/test_placement.py` — 20/20 (select_placement most-free, heterogeneous→None, insufficient-GPUs→None, evict+dedupe across 2 GPUs, **tp==1 == select_gpu** regression, `minimal_tp_to_fit` boundaries/cap/overhead).
- `tests/test_config_resolution.py` — 11/11 (tp=2 in 1-GPU pool raises; tp=2 in 2-GPU pool ok; pool-less-under-declared-pools raises).
- Docker-stubbed smoke: forced-tp config loads, tp>pool-size fail-fast, `estimate_weight_bytes` degrade-to-None.
- **Not yet run on real 2-GPU hardware** — only one 3090 is currently installed. Forced `tp=2` is guarded (config fail-fast / runtime 503) so it degrades safely until the 2nd 3090 lands; the integration items (real 2-GPU launch, auto-fallback on a >24 GB model, evicting a TP resident frees both cards) need that hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)