### PR TITLE
Model co-location (Phase 3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,14 @@ models:
   with `tensor_parallel_size: 1` whose **weights exceed one card** auto-falls-back to the minimal TP
   that fits. TP over PCIe (no NVLink) has real comms cost, so prefer single-GPU when a model fits.
   Each card is still filled to `gpu_memory_utilization` (TP fits bigger *weights*, not more KV).
-- **No co-location.** This release does not co-locate multiple models on one card — each model gets
-  ~its whole GPU at its `gpu_memory_utilization`.
+- **Co-location.** Set `colocate: true` to let small models **share a card**. A co-locatable
+  model's `gpu_memory_utilization` is its intended per-card *share* (e.g. `0.45`, so two fit a 24 GB
+  card); the gateway caps the launch util to the chosen card's *actual free* VRAM (minus a margin,
+  `COLOCATE_MARGIN_MIB`, default 1024) so a second model never OOMs the first. Co-locatable models
+  only share with each other (a whole-card model never shares), are evicted only as needed (idle,
+  LRU), and co-location is **single-GPU only** (not combinable with `tensor_parallel_size > 1`).
+  Default (`colocate: false`) keeps whole-card placement. Expect per-model throughput to drop when a
+  card is shared (contended SMs/KV) — opt in for lightly-used helpers, not your hot path.
 - **GPU source precedence.** `pools:` in config → else `GATEWAY_GPU_UUID` (a single-GPU pool) →
   else all visible GPUs (the legacy single-pool behavior). When no `pools:` are declared, behavior
   is unchanged.

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -13,8 +13,10 @@
 # full UUIDs from `nvidia-smi -L`. A model is placed on a GPU within its pool.
 #   - If 'pools' is omitted, the gateway runs single-pool: the GATEWAY_GPU_UUID
 #     pin if set, else all visible GPUs (unchanged legacy behavior).
-#   - Each model gets ~its whole GPU at its gpu_memory_utilization (whole-card
-#     placement); multi-model co-location is not yet supported.
+#   - By default each model gets ~its whole GPU at its gpu_memory_utilization
+#     (whole-card placement). Set colocate: true to let small models SHARE a card
+#     (their gpu_memory_utilization is their per-card share; co-locatable models only
+#     share with each other; single-GPU only — not combinable with tensor parallel).
 #   - Tensor-parallel (tensor_parallel_size > 1) spreads ONE model across several
 #     GPUs of its pool. TP requires a HOMOGENEOUS pool (equal-VRAM cards) — never
 #     mix a 3090 and an A2000. TP over PCIe (no NVLink) has real comms cost, so use
@@ -64,6 +66,21 @@ models:                        # required, non-empty
     repo: Qwen/Qwen2.5-3B-Instruct
     pool: util
     gpu_memory_utilization: 0.45   # leave headroom for the external embedder on the A2000
+
+  # Two small models that SHARE one 3090 via co-location. Each asks for ~45% of the card
+  # (sum ~0.9 fits one 24 GB GPU); the gateway caps the launch util to actual free space so
+  # the second never OOMs the first. colocate models pack together and are evicted only as
+  # needed. Good for several small helpers that are each lightly used.
+  guard-small:
+    repo: meta-llama/Llama-Guard-3-1B
+    pool: llm
+    colocate: true
+    gpu_memory_utilization: 0.45
+  rewriter-small:
+    repo: Qwen/Qwen2.5-1.5B-Instruct
+    pool: llm
+    colocate: true
+    gpu_memory_utilization: 0.45
 
   # A large model forced across both 3090s with tensor parallel. tensor_parallel_size must
   # not exceed the GPUs declared in the pool (validated at startup), and the pool must be

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -18,7 +18,7 @@ import yaml
 import placement
 from config_loader import (
     ModelConfig, resolve_model_configs, build_fallback_configs,
-    resolve_pools, validate_model_pools, validate_tp_against_pools,
+    resolve_pools, validate_model_pools, validate_tp_against_pools, validate_colocate,
 )
 
 # --- Logging Configuration ---
@@ -65,6 +65,13 @@ GATEWAY_MAX_CONCURRENT = int(os.getenv("GATEWAY_MAX_CONCURRENT", "50"))  # Max c
 # becomes a candidate for eviction-to-make-room. Eviction falls back to fresh models only if no
 # older candidate frees enough VRAM (so a single-GPU swap is never blocked). 0 disables the cooldown.
 GATEWAY_MIN_RESIDENT_SECONDS = int(os.getenv("GATEWAY_MIN_RESIDENT_SECONDS", "90"))
+
+# Co-location (Phase 3): when a co-locatable model shares a card, its launch util is capped so it
+# leaves COLOCATE_MARGIN_MIB free; weights must fit util*total * COLOCATE_WEIGHT_OVERHEAD; a
+# colocate model whose share exceeds COLOCATE_MAX_SHARE is warned about at startup.
+COLOCATE_MARGIN_MIB = int(os.getenv("COLOCATE_MARGIN_MIB", "1024"))
+COLOCATE_WEIGHT_OVERHEAD = float(os.getenv("COLOCATE_WEIGHT_OVERHEAD", "1.15"))
+COLOCATE_MAX_SHARE = float(os.getenv("COLOCATE_MAX_SHARE", "0.9"))
 
 # Timeout configuration (in seconds)
 GATEWAY_REQUEST_TIMEOUT = int(os.getenv("GATEWAY_REQUEST_TIMEOUT", "300"))  # Total request timeout (default 5 minutes)
@@ -149,6 +156,7 @@ class ContainerState:
     inactivity_timeout: int = VLLM_INACTIVITY_TIMEOUT  # per-model idle timeout (seconds; 0 = never unload)
     loaded_at: float = 0.0  # time.time() when the container became ready (for anti-thrash cooldown)
     gpu_uuids: list = field(default_factory=list)  # GPU UUID(s) this container is pinned to
+    colocate: bool = False  # may share its GPU with other co-locatable models (Phase 3)
 
 # --- Docker and HTTP Clients ---
 docker_client = docker.from_env()
@@ -539,6 +547,7 @@ def builtin_model_defaults() -> dict:
         "always_on": False,
         "extra_args": [],
         "pool": None,
+        "colocate": False,
     }
 
 def load_model_configs() -> "tuple[dict, dict]":
@@ -561,6 +570,7 @@ def load_model_configs() -> "tuple[dict, dict]":
         pools = resolve_pools(raw)
         validate_model_pools(configs, pools)  # fail fast on a model referencing an undeclared pool
         validate_tp_against_pools(configs, pools)  # fail fast if tensor_parallel_size > pool GPU count
+        validate_colocate(configs, COLOCATE_MAX_SHARE)  # fail fast on colocate+TP; warn on high share
         logging.info(f"Loaded {len(configs)} model(s) from {MODELS_CONFIG_FILE}: {list(configs)}")
         if pools:
             logging.info(f"Declared GPU pools: { {p: len(u) for p, u in pools.items()} }")
@@ -729,14 +739,17 @@ def merge_extra_args(base: "list[str]", extra: "list[str]") -> "list[str]":
 
 async def start_model_container(model_id: str, container_name: str, model_cfg: ModelConfig,
                                 gpu_uuids: "list[str] | None" = None,
-                                effective_tp: "int | None" = None) -> ContainerState | None:
+                                effective_tp: "int | None" = None,
+                                effective_util: "float | None" = None) -> ContainerState | None:
     """Starts a new vLLM container using the model's resolved configuration.
 
     gpu_uuids pins the container to specific GPU(s) (multi-GPU placement). When None/empty,
     falls back to GPU_DEVICE_REQUESTS (the gateway-wide pin or all GPUs) for backward compat.
-    effective_tp overrides --tensor-parallel-size (for TP fallback); defaults to the model's
-    configured tensor_parallel_size. model_cfg is never mutated (it is shared across requests)."""
+    effective_tp overrides --tensor-parallel-size (for TP fallback); effective_util overrides
+    --gpu-memory-utilization (for co-location). Both default to the model's configured values.
+    model_cfg is never mutated (it is shared across requests)."""
     tp = effective_tp if effective_tp else model_cfg.tensor_parallel_size
+    util = effective_util if effective_util is not None else model_cfg.gpu_memory_utilization
     logging.info(f"Attempting to start model {model_id} in container {container_name}")
 
     # Clean up any existing container with the same name (from crashes or improper shutdowns)
@@ -815,7 +828,7 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
     # --- Build vLLM command from the resolved per-model config ---
     # Always present: --model, --gpu-memory-utilization, --tensor-parallel-size.
     command = ["--model", actual_model_path,
-               "--gpu-memory-utilization", str(model_cfg.gpu_memory_utilization)]
+               "--gpu-memory-utilization", str(round(util, 4))]
     if tp > 0:
         command.extend(["--tensor-parallel-size", str(tp)])
 
@@ -953,6 +966,7 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
                         inactivity_timeout=model_cfg.inactivity_timeout,
                         loaded_at=time.time(),
                         gpu_uuids=list(gpu_uuids) if gpu_uuids else [],
+                        colocate=model_cfg.colocate,
                     )
                 elif response.status_code != 503:
                     # 503 is expected during vLLM initialization; anything else is worth noting
@@ -1136,27 +1150,37 @@ async def proxy_request(request: Request):
                             # Snapshot per-GPU VRAM OUTSIDE the placement lock (it spawns a container).
                             gpus_snapshot = await get_gpu_vram()
 
-                            # Per-card need (whole-card model: independent of TP degree).
-                            if footprint and footprint > 0:
+                            pool_totals = [float(gpus_snapshot.get(u, {}).get("total", 0.0)) for u in pool_gpus]
+                            max_total = max(pool_totals) if pool_totals else 0.0
+                            is_colocate = model_cfg.colocate
+
+                            # Per-card need. Co-locatable models use their intended share (so several pack
+                            # onto a card); whole-card models use the learned footprint or a full-card estimate.
+                            if is_colocate:
+                                needed_per_gpu = model_cfg.gpu_memory_utilization * max_total
+                            elif footprint and footprint > 0:
                                 needed_per_gpu = float(footprint)
                             else:
-                                pool_totals = [float(gpus_snapshot.get(u, {}).get("total", 0.0)) for u in pool_gpus]
-                                needed_per_gpu = model_cfg.gpu_memory_utilization * (max(pool_totals) if pool_totals else 0.0)
+                                needed_per_gpu = model_cfg.gpu_memory_utilization * max_total
 
-                            # Effective TP: forced by config, or auto-fallback for an unseen model whose
-                            # weights exceed one card (only in a homogeneous, multi-GPU pool).
+                            # Effective TP: forced by config, or auto-fallback for an unseen (non-colocate)
+                            # model whose weights exceed one card (only in a homogeneous, multi-GPU pool).
                             effective_tp = model_cfg.tensor_parallel_size
-                            if (is_discovery and model_cfg.tensor_parallel_size == 1 and len(pool_gpus) >= 2):
-                                pool_totals = [float(gpus_snapshot.get(u, {}).get("total", 0.0)) for u in pool_gpus]
-                                if pool_totals and (max(pool_totals) - min(pool_totals)) <= 0.05 * max(pool_totals):
-                                    wbytes = await estimate_weight_bytes(target_model_id)
-                                    min_tp = placement.minimal_tp_to_fit(
-                                        wbytes, max(pool_totals), model_cfg.gpu_memory_utilization, pool_size=len(pool_gpus))
-                                    if min_tp > effective_tp:
-                                        logging.info(f"TP fallback for {target_model_id}: weights ~{wbytes} B -> tp={min_tp}")
-                                        effective_tp = min_tp
+                            if (is_discovery and not is_colocate and model_cfg.tensor_parallel_size == 1
+                                    and len(pool_gpus) >= 2
+                                    and pool_totals and (max(pool_totals) - min(pool_totals)) <= 0.05 * max(pool_totals)):
+                                wbytes = await estimate_weight_bytes(target_model_id)
+                                min_tp = placement.minimal_tp_to_fit(
+                                    wbytes, max_total, model_cfg.gpu_memory_utilization, pool_size=len(pool_gpus))
+                                if min_tp > effective_tp:
+                                    logging.info(f"TP fallback for {target_model_id}: weights ~{wbytes} B -> tp={min_tp}")
+                                    effective_tp = min_tp
+
+                            # Co-location needs a weight estimate to size the launch util safely (best-effort).
+                            colocate_wbytes = await estimate_weight_bytes(target_model_id) if is_colocate else None
 
                             # --- DECIDE: choose GPU(s) + reserve, under the global placement lock ---
+                            effective_util = None
                             async with model_management_lock:
                                 async with placement_lock:
                                     candidates = []
@@ -1173,50 +1197,80 @@ async def proxy_request(request: Request):
                                             ready_footprint=sum(c.vram_footprint for c in residents),
                                         ))
 
-                                    chosen_uuids, evictions = placement.select_placement(
-                                        candidates, residents_by_gpu, needed_per_gpu, effective_tp,
-                                        time.time(), GATEWAY_MIN_RESIDENT_SECONDS,
-                                    )
+                                    if is_colocate:
+                                        uuid, evictions = placement.select_colocated(
+                                            candidates, residents_by_gpu, needed_per_gpu,
+                                            time.time(), GATEWAY_MIN_RESIDENT_SECONDS)
+                                        chosen_uuids = [uuid] if uuid is not None else None
+                                    else:
+                                        chosen_uuids, evictions = placement.select_placement(
+                                            candidates, residents_by_gpu, needed_per_gpu, effective_tp,
+                                            time.time(), GATEWAY_MIN_RESIDENT_SECONDS)
                                     if chosen_uuids is None:
                                         raise HTTPException(
                                             status_code=503,
-                                            detail=(f"Cannot place model {target_model_id} in pool '{pool}' at tp={effective_tp} "
-                                                    f"(~{int(needed_per_gpu)} MiB/GPU): pool not homogeneous, has too few GPUs, "
-                                                    f"or no {effective_tp} GPU(s) free without evicting always_on/in-flight models. Retry later."))
+                                            detail=(f"Cannot place model {target_model_id} in pool '{pool}' "
+                                                    f"({'colocate' if is_colocate else f'tp={effective_tp}'}, ~{int(needed_per_gpu)} MiB/GPU): "
+                                                    f"no GPU available without evicting always_on/in-flight models "
+                                                    f"(or pool not homogeneous / too few GPUs for TP). Retry later."))
+
+                                    # Co-location: size the launch util from the chosen card's free space
+                                    # (after this model's evictions), capped by the configured share and a margin.
+                                    chosen_gv = next(c for c in candidates if c.uuid == chosen_uuids[0])
+                                    if is_colocate:
+                                        freed = sum(r.vram_footprint for r in residents_by_gpu[chosen_uuids[0]]
+                                                    if r.container_name in evictions)
+                                        post_free = chosen_gv.free + freed
+                                        total = chosen_gv.total or max_total
+                                        budget = max(0.0, post_free - COLOCATE_MARGIN_MIB)
+                                        effective_util = min(model_cfg.gpu_memory_utilization,
+                                                             (budget / total) if total > 0 else model_cfg.gpu_memory_utilization)
+                                        # Weights floor: refuse a budget that can't hold the weights (would OOM).
+                                        if colocate_wbytes:
+                                            need_mib = (colocate_wbytes / (1024.0 * 1024.0)) * COLOCATE_WEIGHT_OVERHEAD
+                                            if effective_util * total < need_mib:
+                                                raise HTTPException(
+                                                    status_code=503,
+                                                    detail=(f"Cannot co-locate {target_model_id} on {chosen_uuids[0]}: budget "
+                                                            f"~{int(effective_util * total)} MiB < weights ~{int(need_mib)} MiB. Retry later."))
+                                        reserve_amt = effective_util * total
+                                    else:
+                                        reserve_amt = needed_per_gpu
 
                                     for u in chosen_uuids:
-                                        gpu_reservations[u] = gpu_reservations.get(u, 0.0) + needed_per_gpu
+                                        gpu_reservations[u] = gpu_reservations.get(u, 0.0) + reserve_amt
                                     slot_indices = {int(name.split('_')[-1]) for name in active_containers.keys()}
                                     free_slot = next(i for i in range(len(slot_indices) + 1) if i not in slot_indices)
                                     container_name = f"{VLLM_CONTAINER_PREFIX}_{free_slot}"
-                                    logging.info(f"Placing {target_model_id} on GPU(s) {chosen_uuids} (pool '{pool}', tp={effective_tp}, "
-                                                 f"~{int(needed_per_gpu)} MiB/GPU); evicting {evictions or 'nothing'}; slot {container_name}.")
+                                    logging.info(f"Placing {target_model_id} on GPU(s) {chosen_uuids} (pool '{pool}', "
+                                                 f"{'colocate util=%.3f' % effective_util if is_colocate else 'tp=%d' % effective_tp}, "
+                                                 f"~{int(reserve_amt)} MiB/GPU); evicting {evictions or 'nothing'}; slot {container_name}.")
 
                             # --- Evictions + start happen OUTSIDE the locks (I/O) ---
                             for name in evictions:
                                 await stop_container(name)
 
-                            before_used = gpus_snapshot.get(chosen_uuids[0], {}).get("used", 0.0) if is_discovery else 0.0
+                            # Discovery (whole-card models only): measure the per-GPU footprint delta.
+                            run_discovery = is_discovery and not is_colocate
+                            before_used = gpus_snapshot.get(chosen_uuids[0], {}).get("used", 0.0) if run_discovery else 0.0
 
                             try:
                                 target_container = await start_model_container(
                                     target_model_id, container_name, model_cfg,
-                                    gpu_uuids=chosen_uuids, effective_tp=effective_tp)
+                                    gpu_uuids=chosen_uuids, effective_tp=effective_tp, effective_util=effective_util)
                                 if target_container:
-                                    # Seed footprint with the estimate so concurrent placement counts these
-                                    # GPU(s) as occupied immediately; discovery refines it just below.
-                                    target_container.vram_footprint = needed_per_gpu
+                                    # Seed footprint so concurrent placement counts these GPU(s) as occupied.
+                                    # Co-location: deterministic (vLLM grabs ~util*total). Whole-card: refined by discovery.
+                                    target_container.vram_footprint = reserve_amt
                                     async with model_management_lock:
                                         active_containers[container_name] = target_container
                             finally:
-                                # Always release the optimistic reservation on ALL chosen GPUs (model is now
-                                # resident-and-counted on success, or never loaded on failure).
+                                # Always release the optimistic reservation on ALL chosen GPUs.
                                 async with placement_lock:
                                     for u in chosen_uuids:
-                                        gpu_reservations[u] = max(0.0, gpu_reservations.get(u, 0.0) - needed_per_gpu)
+                                        gpu_reservations[u] = max(0.0, gpu_reservations.get(u, 0.0) - reserve_amt)
 
-                            # Discovery: measure the per-GPU footprint on one chosen GPU (homogeneous + symmetric under TP).
-                            if target_container and is_discovery:
+                            if target_container and run_discovery:
                                 meas_gpu = chosen_uuids[0]
                                 logging.info(f"Discovery: sampling GPU {meas_gpu} VRAM 3x over 45s...")
                                 samples = []

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -22,6 +22,7 @@ ALLOWED_CONFIG_KEYS = {
     "always_on",
     "extra_args",
     "pool",  # name of the GPU pool this model is placed in (multi-GPU); None = default pool
+    "colocate",  # if true, may share a GPU with other co-locatable models (Phase 3)
 }
 
 # Per-model entries additionally require/allow "repo".
@@ -44,6 +45,7 @@ class ModelConfig:
     always_on: bool
     extra_args: list
     pool: Optional[str]  # GPU pool name (multi-GPU placement); None = the default/implicit pool
+    colocate: bool  # may share a GPU with other co-locatable models (Phase 3)
 
 
 def _require_int(field: str, model: str, value):
@@ -95,6 +97,10 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
     if pool is not None and (not isinstance(pool, str) or not pool.strip()):
         raise ValueError(f"model '{name}': 'pool' must be a non-empty string or null, got {pool!r}")
 
+    colocate = merged["colocate"]
+    if not isinstance(colocate, bool):
+        raise ValueError(f"model '{name}': 'colocate' must be a boolean, got {colocate!r}")
+
     return ModelConfig(
         name=name,
         repo=repo,
@@ -108,6 +114,7 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
         # Fresh list of strings; never share the builtins/defaults list across models.
         extra_args=[str(a) for a in extra_args],
         pool=pool.strip() if isinstance(pool, str) else None,
+        colocate=colocate,
     )
 
 
@@ -249,3 +256,26 @@ def validate_tp_against_pools(configs: "dict[str, ModelConfig]", pools: "dict[st
                     f"model '{name}': tensor_parallel_size={cfg.tensor_parallel_size} exceeds the "
                     f"{available} GPU(s) declared in pool '{cfg.pool}'"
                 )
+
+
+def validate_colocate(configs: "dict[str, ModelConfig]", max_share: float = 0.9) -> None:
+    """Validate co-location settings. Raises on a hard conflict; warns on a soft smell.
+
+    Co-location is single-GPU only, so it is incompatible with tensor parallel. A co-locatable
+    model whose share (gpu_memory_utilization) is near a whole card won't actually co-locate —
+    that's a config smell, logged as a warning, not an error.
+    """
+    import logging
+    for name, cfg in configs.items():
+        if not cfg.colocate:
+            continue
+        if cfg.tensor_parallel_size > 1:
+            raise ValueError(
+                f"model '{name}': colocate=true is incompatible with tensor_parallel_size="
+                f"{cfg.tensor_parallel_size} (co-location is single-GPU only)"
+            )
+        if cfg.gpu_memory_utilization > max_share:
+            logging.warning(
+                f"model '{name}': colocate=true but gpu_memory_utilization="
+                f"{cfg.gpu_memory_utilization} > {max_share}; it will rarely fit alongside another model."
+            )

--- a/gateway/placement.py
+++ b/gateway/placement.py
@@ -202,3 +202,39 @@ def select_placement(candidates, residents_by_gpu, needed_per_gpu, tp, now, min_
     # Dedupe eviction names (a multi-GPU/TP resident can appear on several chosen GPUs).
     evictions = list(dict.fromkeys(n for o in chosen for n in o[3]))
     return chosen_uuids, evictions
+
+
+def select_colocated(candidates, residents_by_gpu, needed, now, min_resident_seconds):
+    """Choose a GPU for a co-locatable model that may SHARE a card with other co-locatable models.
+
+    Returns (chosen_uuid | None, eviction_names). Single GPU.
+
+    A GPU is eligible only if it is empty or every resident on it is itself co-locatable
+    (a co-locatable model never shares with a whole-card model). Among eligible GPUs: direct fit
+    (free >= needed) most-free first; else evict idle co-residents guarded-LRU *only as much as
+    needed* (reuse _gpu_fit_cost — it stops once `needed` fits, so co-residents are kept when
+    possible); else None (caller 503s).
+    """
+    eligible = [
+        g for g in candidates
+        if all(getattr(r, "colocate", False) for r in residents_by_gpu.get(g.uuid, []))
+    ]
+
+    # 1. Direct fit, most-free first.
+    direct = [g for g in eligible if g.free >= needed]
+    if direct:
+        return max(direct, key=lambda g: g.free).uuid, []
+
+    # 2. Partial guarded eviction of idle co-residents.
+    options = []  # (num_evictions, -resulting_free, uuid, eviction_names)
+    for g in eligible:
+        cost = _gpu_fit_cost(g, residents_by_gpu.get(g.uuid, []), needed, now, min_resident_seconds)
+        if cost is not None:
+            num_ev, resulting_free, ev = cost
+            options.append((num_ev, -resulting_free, g.uuid, ev))
+
+    if not options:
+        return None, []
+    options.sort()
+    _, _, uuid, evictions = options[0]
+    return uuid, evictions

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -13,7 +13,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
 from config_loader import (  # noqa: E402
     resolve_model_configs, build_fallback_configs, resolve_pools,
-    validate_model_pools, validate_tp_against_pools,
+    validate_model_pools, validate_tp_against_pools, validate_colocate,
 )
 
 # Mirrors app.builtin_model_defaults() with stock env-var defaults.
@@ -27,6 +27,7 @@ BUILTINS = {
     "always_on": False,
     "extra_args": [],
     "pool": None,
+    "colocate": False,
 }
 
 
@@ -228,6 +229,36 @@ def test_validate_tp_against_pools():
     # no pools declared -> never raises on tp
     validate_tp_against_pools(bad, {})
     print("ok: validate_tp_against_pools")
+
+
+def test_colocate_field_and_validation():
+    # default false; override true; precedence via defaults
+    cfgs = resolve_model_configs(
+        {"defaults": {"colocate": True}, "models": {"a": {"repo": "o/a"}, "b": {"repo": "o/b", "colocate": False}}},
+        BUILTINS)
+    assert cfgs["a"].colocate is True and cfgs["b"].colocate is False
+    # non-bool rejected
+    try:
+        resolve_model_configs({"models": {"m": {"repo": "o/m", "colocate": "yes"}}}, BUILTINS)
+    except ValueError as e:
+        assert "colocate" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for non-bool colocate")
+    print("ok: colocate field + type validation")
+
+
+def test_validate_colocate_forbids_tp():
+    ok = resolve_model_configs({"models": {"m": {"repo": "o/m", "colocate": True}}}, BUILTINS)
+    validate_colocate(ok)  # tp defaults to 1 -> fine
+    bad = resolve_model_configs(
+        {"models": {"m": {"repo": "o/m", "colocate": True, "tensor_parallel_size": 2}}}, BUILTINS)
+    try:
+        validate_colocate(bad)
+    except ValueError as e:
+        assert "incompatible" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for colocate + tp>1")
+    print("ok: validate_colocate forbids TP")
 
 
 if __name__ == "__main__":

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
 from placement import (  # noqa: E402
     select_evictions, select_gpu, GpuView, select_placement, minimal_tp_to_fit, _homogeneous,
+    select_colocated,
 )
 
 
@@ -23,6 +24,7 @@ class R:  # minimal stand-in for ContainerState
     loaded_at: float = 0.0
     active_requests: int = 0
     always_on: bool = False
+    colocate: bool = False
 
 
 NOW = 1_000_000.0
@@ -207,6 +209,55 @@ def test_select_placement_tp_evicts_and_dedupes():
     chosen, ev = select_placement([a, b], {"A": ra, "B": rb}, 20000, 2, NOW, 90)
     assert sorted(chosen) == ["A", "B"]
     assert sorted(ev) == ["ra", "rb"] and len(ev) == len(set(ev)), ev
+
+
+# --- select_colocated (Phase 3) ---
+
+def test_colocated_empty_gpu_direct_fit():
+    g = GpuView("A", 24000, used_smi=0)
+    uuid, ev = select_colocated([g], {"A": []}, 10800, NOW, 90)
+    assert uuid == "A" and ev == []
+
+
+def test_colocated_shares_with_colocate_resident():
+    # A already holds a colocate model (10800); a second colocate model (10800) fits alongside.
+    a = GpuView("A", 24000, used_smi=10800, ready_footprint=10800)
+    res = [R("a1", 10800, OLD, loaded_at=OLD, colocate=True)]
+    uuid, ev = select_colocated([a], {"A": res}, 10800, NOW, 90)
+    assert uuid == "A" and ev == [], (uuid, ev)
+
+
+def test_colocated_rejects_wholecard_resident():
+    # A holds a non-colocate (whole-card) model -> not eligible for co-location.
+    a = GpuView("A", 24000, used_smi=12000, ready_footprint=12000)
+    res = [R("wc", 12000, OLD, loaded_at=OLD, colocate=False)]
+    uuid, ev = select_colocated([a], {"A": res}, 10800, NOW, 90)
+    assert uuid is None, (uuid, ev)
+
+
+def test_colocated_evicts_only_as_needed():
+    # Card full of two idle colocate models; need room for one more -> evict the single LRU.
+    a = GpuView("A", 24000, used_smi=24000, ready_footprint=24000)
+    res = [R("old", 12000, NOW - 900, loaded_at=OLD, colocate=True),
+           R("new", 12000, NOW - 5, loaded_at=OLD, colocate=True)]
+    uuid, ev = select_colocated([a], {"A": res}, 10000, NOW, 90)
+    assert uuid == "A" and ev == ["old"], (uuid, ev)  # evict just the LRU, keep the other
+
+
+def test_colocated_all_alwayson_returns_none():
+    a = GpuView("A", 24000, used_smi=24000, ready_footprint=24000)
+    res = [R("p", 24000, OLD, loaded_at=OLD, colocate=True, always_on=True)]
+    uuid, ev = select_colocated([a], {"A": res}, 10000, NOW, 90)
+    assert uuid is None, (uuid, ev)
+
+
+def test_colocated_picks_most_free_eligible():
+    a = GpuView("A", 24000, used_smi=10800, ready_footprint=10800)  # free 13200
+    b = GpuView("B", 24000, used_smi=2000, ready_footprint=2000)     # free 22000
+    rbg = {"A": [R("a1", 10800, OLD, loaded_at=OLD, colocate=True)],
+           "B": [R("b1", 2000, OLD, loaded_at=OLD, colocate=True)]}
+    uuid, ev = select_colocated([a, b], rbg, 8000, NOW, 90)
+    assert uuid == "B" and ev == []
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #6 (base `placement-phase-2`) — shows only the Phase 3 diff. Merge #4 → #5 → #6 → this in order.

## What
Let multiple **opt-in** small models share one GPU via dynamic `gpu_memory_utilization`. Default behavior unchanged; **single-GPU only** (not combinable with tensor parallel). Testable now on the single 3090.

**Sizing (the crux).** A co-locatable model's `gpu_memory_utilization` is its intended per-card *share* (e.g. `0.45` → two fit a 24 GB card). At launch the util is **capped to the chosen card's actual free VRAM** minus a margin (`COLOCATE_MARGIN_MIB`, default 1024), so a second model never OOMs the first — vLLM sizes KV as `util × TOTAL` and checks it against *free*. Footprint is then deterministic (`effective_util × total`), so **co-located models skip the discovery measurement**; discovery still runs only for whole-card models, which never share a card.

## Changes
- **`config_loader.py`** — `colocate` key + `ModelConfig.colocate` (bool, validated); `validate_colocate()` (fail-fast on `colocate` + `tensor_parallel_size > 1`; warn on near-whole-card share).
- **`placement.py`** — `select_colocated()`: a GPU is eligible only if empty or holding *only* co-locatable residents; direct-fit most-free, then guarded **partial** LRU eviction (reuses `_gpu_fit_cost`/`select_evictions`, keeps co-residents when possible).
- **`app.py`** — `COLOCATE_MARGIN_MIB`/`WEIGHT_OVERHEAD`/`MAX_SHARE` env; `builtins["colocate"]=False`; `ContainerState.colocate`; `start_model_container(effective_util=)` threaded into `--gpu-memory-utilization` (no mutation of the shared `model_cfg`); co-location placement branch (share sizing → `select_colocated` → dynamic `effective_util` from the chosen card's free space → weights-floor guard → skip discovery → 503 on no-fit). TP fallback is skipped for colocate models.

## Backward compatibility
`colocate: false` (default) → `effective_util=None` → builder uses the configured util; whole-card `select_placement`. TP / pools / no-pools / `ALLOWED_MODELS_JSON` paths untouched; `select_gpu`/`select_placement`/`select_evictions`/`minimal_tp_to_fit` unchanged.

## Test plan
- `ast.parse` on all three modules.
- `tests/test_placement.py` — 26/26 (colocate share, reject whole-card resident, evict-only-as-needed/LRU, most-free, all-always_on→None; plus all prior incl. tp==1 regression).
- `tests/test_config_resolution.py` — 13/13 (colocate field/default/non-bool; colocate+tp2 raises).
- Docker-stubbed smoke: colocate config loads, colocate+tp2 fail-fast, and a real `start_model_container` call confirming `effective_util=0.42` reaches `--gpu-memory-utilization`.
- **Not yet run on real hardware.** Single-3090 integration to do: two `colocate: true, gpu_memory_utilization: 0.45` models land on the same GPU (`/gateway/status` shows both under one `gpu_uuid`), both answer, no OOM; a `colocate:false` model evicts the co-residents instead of sharing; an over-subscribed share is capped or 503s rather than OOMing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)