### PR TITLE
Harden placement — Stage 1 (block-independent review fixes)

### DIFF
--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -41,7 +41,9 @@ defaults:                      # optional; applied to every model unless overrid
   dtype: auto                  # auto | float16 | bfloat16 | ...
   inactivity_timeout: 1800     # seconds of idleness before unload; 0 = never unload
   always_on: false             # if true, never auto-unloaded
-  extra_args: []               # raw vLLM CLI args, appended verbatim (override generated flags)
+  extra_args: []               # raw vLLM CLI args, appended verbatim. NOTE: --model,
+                               # --gpu-memory-utilization and --tensor-parallel-size are
+                               # gateway-managed (set from placement) and ignored here if present.
 
 models:                        # required, non-empty
   # A small instruct model on its native context length (default pool: llm).

--- a/docs/review-findings.md
+++ b/docs/review-findings.md
@@ -1,0 +1,223 @@
+# vLLM Gateway — Implementation Review Findings
+
+Diligent review of the placement engine across Phases 1a–3 (PRs #4–#7). **Documentation only —
+nothing here is fixed.** Each finding was verified against the source (file:line confirmed) and
+tagged:
+
+- **[pre-existing]** — predates the placement phase work (originates in the earlier streaming/queue code).
+- **[introduced]** — added or materially worsened by Phases 1a/1b/2/3.
+
+Scope: `gateway/app.py`, `gateway/placement.py`, `gateway/config_loader.py`, `config/models.yaml.example`,
+`docker-compose.yml`. Line numbers are as of branch `placement-phase-3` and will drift.
+
+## Fix status (branch `placement-hardening`)
+
+**Stage 1 — DONE** (block-independent fixes; no concurrency-model change):
+- **F6** ✅ `merge_extra_args` now drops + warns on gateway-managed flags (`GATEWAY_MANAGED_FLAGS`).
+- **F8/F11** ✅ probe is now `count=-1` (sees all GPUs; pin no longer constrains it) + post-probe
+  `validate_pools_visible` fail-fast; `TOTAL_GPU_VRAM` recomputed from the managed set.
+- **F10** ✅ `gateway_status` is `async` and snapshots shared state under locks.
+- **F15** ✅ `save_known_footprints_async` runs the write off the event loop.
+- **F16** ✅ stale GPU-pin and "POOL-BASED (no TP/colocation)" comments corrected.
+
+**Stage 2 — PENDING** (all touch the placement decision block; done together to avoid double churn):
+- **F1, F3, F4, F7, F13** — the concurrency-core refactor (status state machine + single `state_lock`
+  + reconciler).
+- **F2, F9** — deterministic `effective_tp` + per-card `need_fn` + footprint re-key (wired into the
+  rewritten block).
+- **F5** — fold the `TOTAL_GPU_VRAM==0` bypass into the unified path.
+
+*(Sequencing note: the approved plan placed F2/F9/F5 in Stage 1, but they edit the same placement
+block that the Stage 2 rewrite replaces, so they were moved to Stage 2 to avoid editing it twice.
+Same fixes, fewer rewrites.)*
+
+
+---
+
+## ⚠️ Read this first: the lock interaction
+
+The over-broad `queue_count_lock` (**F1**) currently **masks most of the concurrency hazards below**.
+Because one global lock is held across the entire placement+proxy path, only one request is ever in
+that region at a time, so the slot-collision (F4), reserved-but-not-resident (F7), and double-booking
+races **cannot fire today**. They go live the moment F1 is fixed.
+
+➡️ **F1 must be fixed together with F3, F4, F7 — not before them.** Fixing F1 alone would expose the
+masked races.
+
+---
+
+## Critical
+
+### F1 — `queue_count_lock` held across the whole request lifecycle  `[pre-existing, amplified]`
+`app.py:1115` opens `async with queue_count_lock:` and the block (indent 12) extends through
+placement, `start_model_container` (health-check loop up to ~1 h), the 45 s discovery sleeps, and the
+entire non-streaming proxy — closing only at the outer `finally` (~`app.py:1432`). The comments
+"Outside all locks" at `app.py:1313` and `1335` are **false**.
+
+- **Effect:** the admission/queue-counter lock is effectively global. A second request *for any model*
+  blocks behind the first request's cold-start/proxy at the admission `async with queue_count_lock`
+  (~`app.py:1063`). `GATEWAY_MAX_CONCURRENT` and the per-model semaphores are defeated; the gateway
+  serializes globally.
+- **Phase amplification:** the phases added, *inside* this lock, per-GPU `get_gpu_vram()` probes (each
+  spawns a container), `estimate_weight_bytes()` HTTP calls, and 3×15 s discovery sleeps — greatly
+  extending the hold time.
+- **Fix shape:** the block should close right after the counter decrement (~`app.py:1118`); everything
+  below belongs outside it.
+
+---
+
+## High
+
+### F2 — Auto-TP-fallback footprint reused for a later single-GPU placement → OOM  `[introduced: Phase 2]`
+For a `tensor_parallel_size: 1` model whose weights exceed one card:
+1. First request: `is_discovery=True` → TP fallback sets `effective_tp=2` → discovery stores a
+   **per-GPU** footprint under `known_footprints[model_id]` (~`app.py:1283`).
+2. Next request: `footprint>0` ⇒ `is_discovery=False`, so the fallback block (guarded by `is_discovery`)
+   is skipped → `effective_tp` reverts to the configured `1`, and `needed_per_gpu` = the half-size
+   per-GPU footprint → the model is placed on **one** GPU with `--tensor-parallel-size 1` → OOM at load.
+
+The fallback *decision* is never persisted. Forced-TP models (config `tp≥2`) are unaffected.
+**Root cause is architectural:** `known_footprints` is keyed by `model_id` only (see Architecture §A1).
+
+### F3 — Reservation leak if eviction throws between reserve and the `try/finally`  `[introduced: 1b]` *(masked by F1)*
+Reservations are added under the lock (~`app.py:1240`), then the eviction loop
+`for name in evictions: await stop_container(name)` runs **before** the `try:` whose `finally` frees
+them (~`app.py:1257`/`1268`). `stop_container` only catches `NotFound`/`APIError`; any other error — or a
+`CancelledError` (client disconnect) anywhere in that gap — escapes before the `finally`, permanently
+leaking `reserve_amt` on the chosen GPU(s) and progressively shrinking their `free` (→ eventual 503s).
+The reserve-add and the eviction loop should sit inside the same `try`.
+
+### F4 — Slot-name collision clobbers a freshly-started container  `[pre-existing for known-footprint path; now all paths]` *(masked by F1)*
+`free_slot`/`container_name` are computed from `active_containers` under the lock (~`app.py:1242`) but
+the name is not inserted until after `start_model_container` returns (~`app.py:1266`) — minutes later,
+after the locks release. Two requests for **different** models can compute the same `vllm_server_N`;
+the second's stale-container cleanup (`start_model_container` ~`app.py:756–785`, `remove(force=True)`)
+then destroys the first's container. Only safe today because F1 serializes the whole region.
+
+### F5 — VRAM-management-disabled fallback bypasses pools and device pinning  `[introduced: not updated in 1b/2/3]`
+The `else:` branch when `TOTAL_GPU_VRAM == 0` (~`app.py:1305`) calls
+`start_model_container(target_model_id, container_name, model_cfg)` with **no `gpu_uuids` /
+`effective_tp` / `effective_util`** → device selection falls back to `GPU_DEVICE_REQUESTS` (all GPUs or
+the instance pin), `ContainerState.gpu_uuids=[]`. So a `pool: util` model is **not** confined to the
+A2000 and never appears in per-GPU accounting / `/gateway/status`. Triggers whenever the startup VRAM
+probe fails on a host that declares `pools:`.
+
+---
+
+## Medium
+
+### F6 — `extra_args` silently overrides gateway-computed `--gpu-memory-utilization` / `--tensor-parallel-size`  `[introduced: interaction]`
+`merge_extra_args` (`app.py:712`) drops the gateway's flag whenever the user supplies the same one. So
+`extra_args: ["--gpu-memory-utilization","0.95"]` defeats the co-location `effective_util` cap (OOM
+risk), and a `--tensor-parallel-size` in `extra_args` bypasses `validate_tp_against_pools`. No warning;
+`models.yaml.example` even advertises "override generated flags." The gateway-managed flags should be
+protected or at least warned about.
+
+### F7 — `select_colocated` ignores a reserved-but-not-yet-resident whole-card model  `[introduced: Phase 3]` *(partly masked by F1 + reservation)*
+Eligibility (`placement.py:~218`) is computed from `active_containers` only. A whole-card model
+mid-launch is in `gpu_reservations` but not yet a "resident", so the GPU looks empty/eligible and a
+colocate model could land on a card a whole-card model is loading onto. The reservation reduces
+`GpuView.free` (partial protection) and F1 serializes starts today, but the eligibility predicate
+itself is unsound.
+
+### F8 — Pool with zero *visible* GPUs isn't caught; config validation runs before the GPU probe  `[introduced: 1b]`
+`validate_model_pools` / `validate_tp_against_pools` / `validate_colocate` run at import (before
+`get_total_vram` / `resolve_managed_pools`). A pool whose UUIDs are typos passes validation; at runtime
+those candidates get `total=0` → `free<0` → never chosen, and for TP a `0`-total breaks `_homogeneous`
+→ permanent 503 with only a startup WARNING (~`app.py:373`). Medium-confidence cascade:
+`run_nvidia_smi_in_container` requests `device_ids=MANAGED_GPUS`; if one UUID is invalid Docker may
+error the **whole** probe → all VRAM reads return 0.
+
+### F9 — `needed_per_gpu = util × max(pool_totals)` is wrong on a mixed-size pool  `[introduced: 1b]`
+`app.py:~1154` uses the pool's largest card for every candidate, but vLLM targets `util × that card's
+total`. Harmless for homogeneous pools (the intended use), but a pool mixing card sizes (not prevented
+by config) mis-sizes the fit check per card. Should be `util × g.total` per candidate.
+
+### F10 — `/gateway/status` iterates shared dicts with no lock  `[introduced: status reads grew in 1b]`
+`gateway_status` (sync `def`, runs in a threadpool) iterates `active_containers` / `gpu_reservations` /
+`model_queue_counts` / `GPU_VRAM` (~`app.py:1003–1031`) while async paths mutate them under locks →
+possible `RuntimeError: dictionary changed size during iteration` (500). Field serialization itself is
+fine (`gpu_uuids` list, `colocate` bool are JSON-clean).
+
+### F11 — `get_total_vram()` runs before `resolve_managed_pools()`; pin constrains the initial probe  `[introduced: 1b/3 ordering]`
+At startup the probe uses `GPU_DEVICE_REQUESTS`. With both `pools:` **and** `GATEWAY_GPU_UUID` set, only
+the pinned GPU is probed, so `GPU_VRAM` has one entry and every other pool GPU becomes "unseen" (→ F8).
+`pools:` is meant to win over the pin, but the pin still constrains the initial probe — inconsistent
+precedence.
+
+---
+
+## Low
+
+### F12 — Co-located footprint is the configured *share*, not actual use; never re-measured  `[introduced: Phase 3 — design limitation, not a bug]`
+`vram_footprint = effective_util×total` for colocate models and discovery is skipped, so packing is by
+*configured share*, conservatively. **Note (correcting an over-statement from the review):** this does
+**not** drive `free` negative or block legitimate packing — the fit-check guarantees
+`Σ resident footprints ≤ total`. It just means shares must be tuned; the gateway won't auto-discover
+that a model uses less than its declared share.
+
+### F13 — Streaming generator owns its own `active_requests` / semaphore release  `[pre-existing]`
+If the ASGI layer ever builds the `StreamingResponse` but doesn't drive the generator to its `finally`
+(~`app.py:1374`), both the semaphore slot and `active_requests` leak (container becomes permanently
+non-evictable). Normally Starlette closes the generator on disconnect, so this is an edge case.
+
+### F14 — Weight estimate is dtype-blind; GGUF returns `None` → no TP fallback  `[introduced: Phase 2]`
+`estimate_weight_bytes` reads the safetensors index `total_size`; vLLM may upcast (e.g. fp8→bf16) so the
+`1.2`/`1.15` overhead factors can under-count, and GGUF / non-safetensors models get no TP-fallback
+sizing (silently attempt single-card → OOM). The degradation is "fail loud at launch," acceptable but
+undocumented.
+
+### F15 — Blocking `save_known_footprints()` on the event loop, under locks  `[pre-existing, now under more locks]`
+`app.py:~1289` calls synchronous `json.dump` directly (not via `run_in_executor`) inside the per-model
+lock and F1's global lock.
+
+### F16 — Stale comments / docstrings  `[introduced]`
+- `app.py:~1140` "POOL-BASED PLACEMENT (whole-card model; no TP, no co-location)" sits above code that
+  now does both TP and co-location.
+- `app.py:51–53` GPU-pin comment doesn't mention that `pools:` overrides it (docker-compose.yml does).
+- "Outside all locks" at `app.py:1313`/`1335` is false (F1).
+
+---
+
+## Architectural observations
+
+**A1 — Footprint registry keyed by `model_id` only.** The real VRAM need depends on placement (TP
+degree, card size, util share). F2 and F9 are both symptoms. A footprint key should encode
+`(repo, effective_tp, util, card_total)`, or footprints should be per-(model, gpu-class). The TP
+fallback decision should also be persisted, not re-derived only during discovery.
+
+**A2 — Two sources of truth for VRAM.** nvidia-smi `used_smi` vs app-tracked `ready_footprint` /
+`reserved`, reconciled by `max()` + subtraction (`placement.py:30`). It works but is subtle.
+External-process VRAM on a shared card (the A2000 embedder) is only ever *reacted to*; an
+over-subscribed external process yields a clean 503 on that card (expected — **not** a needless-eviction
+bug: `_gpu_fit_cost` returns `None` without evicting when nothing fits).
+
+**A3 — Overloaded lock model.** `queue_count_lock` doubles as a de-facto global request lock (F1). A
+clean design wants: a short counter lock, the already-added briefly-held `placement_lock`, and the
+reservation as the only cross-request VRAM guard (with the reserve+evict made atomic per F3).
+
+---
+
+## Verified NOT bugs (recorded so they are not re-raised)
+
+- `select_placement` TP picks **distinct** GPUs (one `GpuView` per pool GPU); no same-GPU-twice.
+- `minimal_tp_to_fit` correctly caps at `pool_size`.
+- Unit handling (bytes vs MiB) is consistent across `estimate_weight_bytes`, `minimal_tp_to_fit`, the
+  co-location floor, and `GpuView`.
+- The documented lock order (`container_start_lock → model_management_lock → placement_lock`) is
+  followed; `get_gpu_vram()` is correctly snapshotted *outside* `placement_lock`.
+- Queue-counter / semaphore cleanup on the new 503/500 paths does **not** leak (the
+  `counter_needs_cleanup` flag + outer `finally` handle it).
+
+---
+
+## Suggested triage order (when fixing later)
+
+1. **F1 + F3 + F4 + F7 together** (lock scope + reservation atomicity + slot allocation + colocate
+   eligibility) — they are coupled; fixing F1 alone exposes the others.
+2. **F2** (persist TP-fallback / footprint keying) — silent OOM on the second request.
+3. **F5** (VRAM-disabled fallback honors pools) and **F6** (protect managed flags) — correctness/safety.
+4. **F8/F11** (fail-fast on 0 visible GPUs; probe ordering) and **F10** (lock the status reads).
+5. Low / docs: F12–F16.
+
+*Generated by an implementation review; findings verified against source on branch `placement-phase-3`.*

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -19,6 +19,7 @@ import placement
 from config_loader import (
     ModelConfig, resolve_model_configs, build_fallback_configs,
     resolve_pools, validate_model_pools, validate_tp_against_pools, validate_colocate,
+    validate_pools_visible,
 )
 
 # --- Logging Configuration ---
@@ -49,8 +50,9 @@ VLLM_TEMP_DIR = os.getenv("VLLM_TEMP_DIR", "/tmp")
 MODELS_CONFIG_FILE = os.getenv("MODELS_CONFIG_FILE", "/app/config/models.yaml")
 
 # --- GPU Pinning ---
-# Optionally pin this gateway instance (and every vLLM container it launches) to a
-# single GPU by UUID. Leave unset to use all GPUs (default, unchanged behavior).
+# Optionally pin this gateway instance (and every vLLM container it launches) to a single GPU
+# by UUID. For multi-GPU, prefer a `pools:` section in the model config (which takes precedence
+# over this pin). Leave unset and with no pools to use all visible GPUs (legacy behavior).
 GATEWAY_GPU_UUID = os.getenv("GATEWAY_GPU_UUID", "").strip()
 if GATEWAY_GPU_UUID:
     GPU_DEVICE_REQUESTS = [DeviceRequest(device_ids=[GATEWAY_GPU_UUID], capabilities=[['gpu']])]
@@ -209,8 +211,12 @@ async def lifespan(_app: FastAPI):
         RESOLVED_DOCKER_NETWORK = DOCKER_NETWORK_NAME
         logging.error(f"Gateway container '{GATEWAY_CONTAINER_NAME}' not found. Falling back to network '{DOCKER_NETWORK_NAME}'.")
 
-    await get_total_vram()
+    await get_total_vram()  # probes ALL GPUs -> GPU_VRAM (independent of any pin)
     resolve_managed_pools()
+    # Fail fast if a configured pool/pin UUID isn't actually present (typo / moved card),
+    # rather than silently treating it as a 0-VRAM, unplaceable GPU.
+    if CONFIGURED_POOLS or GATEWAY_GPU_UUID:
+        validate_pools_visible(MANAGED_POOLS, set(GPU_VRAM.keys()))
     load_known_footprints()
     asyncio.create_task(shutdown_inactive_containers())
 
@@ -235,13 +241,10 @@ async def run_in_executor(func, *args, **kwargs):
 async def run_nvidia_smi_in_container(command: list[str]) -> str:
     """Runs an nvidia-smi command in a temporary container and returns the output.
 
-    The probe must see every GPU this gateway manages so per-GPU accounting is complete.
-    Once pools are resolved it requests exactly the managed set; before that (startup) it
-    falls back to GPU_DEVICE_REQUESTS (the GATEWAY_GPU_UUID pin, or all GPUs)."""
-    if MANAGED_GPUS:
-        probe_requests = [DeviceRequest(device_ids=list(MANAGED_GPUS), capabilities=[['gpu']])]
-    else:
-        probe_requests = GPU_DEVICE_REQUESTS
+    The probe always requests ALL GPUs (count=-1) and the caller filters to the managed set.
+    This keeps per-GPU accounting complete regardless of the GATEWAY_GPU_UUID pin (so pools
+    win over the pin), and avoids a single bad configured UUID erroring the whole probe."""
+    probe_requests = [DeviceRequest(count=-1, capabilities=[['gpu']])]
     try:
         smi_output = await run_in_executor(
             docker_client.containers.run,
@@ -341,6 +344,10 @@ def save_known_footprints():
     except IOError as e:
         logging.error(f"Could not save memory footprints file: {e}")
 
+async def save_known_footprints_async():
+    """Persist footprints off the event loop (blocking file I/O must not run on the loop)."""
+    await run_in_executor(save_known_footprints)
+
 async def get_used_vram() -> float:
     """Gets currently used GPU VRAM (MiB) across the managed GPU(s)."""
     gpus = await get_gpu_vram()
@@ -370,11 +377,11 @@ def resolve_managed_pools():
     MANAGED_GPUS = [u for uuids in MANAGED_POOLS.values() for u in uuids]
     logging.info(f"Managed GPU pools resolved from {source}: "
                  f"{ {p: u for p, u in MANAGED_POOLS.items()} }")
-    # Warn about configured UUIDs the probe can't see (typo / wrong host).
+    # Recompute the managed total from the resolved set so it reflects pools (which win over the
+    # pin), not whatever _managed_vram defaulted to before resolution.
+    global TOTAL_GPU_VRAM
     if GPU_VRAM:
-        unseen = [u for u in MANAGED_GPUS if u not in GPU_VRAM]
-        if unseen:
-            logging.warning(f"Configured GPU UUID(s) not visible to nvidia-smi: {unseen}")
+        TOTAL_GPU_VRAM = int(sum(GPU_VRAM[u]["total"] for u in MANAGED_GPUS if u in GPU_VRAM))
 
 def pool_for(model_cfg) -> str:
     """The pool a model belongs to: its configured pool, else the default/implicit pool."""
@@ -709,14 +716,38 @@ async def estimate_weight_bytes(model_id: str) -> "int | None":
         logging.warning(f"Could not estimate weight size for {model_id}: {e}")
     return None
 
+# Flags the gateway computes from placement (util cap, TP degree, model path). A model's
+# extra_args must NOT override these — doing so would defeat the co-location budget or the
+# pool-validated tensor-parallel degree. They are dropped (with a warning) if present.
+GATEWAY_MANAGED_FLAGS = {"--gpu-memory-utilization", "--tensor-parallel-size", "--model"}
+
 def merge_extra_args(base: "list[str]", extra: "list[str]") -> "list[str]":
-    """Append raw extra_args verbatim, letting them override any flag the base set.
+    """Append raw extra_args, letting them override any NON-managed flag the base set.
 
     Any '--flag' present in extra_args removes the gateway-generated occurrence of that
     flag (and its following value, if any) from base, so the explicit config value wins
-    and no flag is duplicated.
+    and no flag is duplicated — except GATEWAY_MANAGED_FLAGS, which the gateway owns and
+    which are stripped from extra_args (with a warning) so placement decisions stand.
     """
     extra = [str(a) for a in extra]
+
+    # Strip gateway-managed flags (and their values) from extra_args.
+    cleaned = []
+    i = 0
+    while i < len(extra):
+        tok = extra[i]
+        if tok in GATEWAY_MANAGED_FLAGS:
+            logging.warning(f"Ignoring gateway-managed flag '{tok}' in extra_args "
+                            f"(it is set from placement and cannot be overridden).")
+            if i + 1 < len(extra) and not extra[i + 1].startswith("--"):
+                i += 2
+            else:
+                i += 1
+            continue
+        cleaned.append(tok)
+        i += 1
+    extra = cleaned
+
     extra_flags = {tok for tok in extra if tok.startswith("--")}
     if not extra_flags:
         return base + extra
@@ -1001,34 +1032,49 @@ def list_models():
     return {"data": [{"id": name} for name in ALLOWED_MODELS.keys()], "object": "list"}
 
 @app.get("/gateway/status")
-def gateway_status():
-    """Returns the current status of the gateway and its managed containers."""
-    # Per-GPU view: which pool each managed GPU is in, its residents, and reservation.
-    uuid_to_pool = {u: p for p, uuids in MANAGED_POOLS.items() for u in uuids}
+async def gateway_status():
+    """Returns the current status of the gateway and its managed containers.
+
+    Snapshots the shared state under the locks that guard it, then builds the response from
+    the copies — so a concurrent mutation can't raise 'dict changed size during iteration'
+    (this endpoint runs in a threadpool, truly concurrent with the event loop)."""
+    async with model_management_lock:
+        async with placement_lock:
+            containers = {name: dict(state.__dict__) for name, state in active_containers.items()}
+            reservations = dict(gpu_reservations)
+        gpu_vram = {u: dict(v) for u, v in GPU_VRAM.items()}
+        pools = {p: list(u) for p, u in MANAGED_POOLS.items()}
+        footprints = dict(known_footprints)
+        managed = list(MANAGED_GPUS)
+    async with queue_count_lock:
+        queue_counts = dict(model_queue_counts)
+
+    uuid_to_pool = {u: p for p, uuids in pools.items() for u in uuids}
     gpus_status = {}
-    for guid in MANAGED_GPUS:
-        v = GPU_VRAM.get(guid, {})
-        residents = [c.container_name for c in active_containers.values() if guid in c.gpu_uuids]
+    for guid in managed:
+        v = gpu_vram.get(guid, {})
+        residents = [c["container_name"] for c in containers.values() if guid in c.get("gpu_uuids", [])]
         gpus_status[guid] = {
             "pool": uuid_to_pool.get(guid),
             "total_mib": v.get("total"),
             "used_mib": v.get("used"),
-            "reserved_mib": gpu_reservations.get(guid, 0.0),
+            "reserved_mib": reservations.get(guid, 0.0),
             "residents": residents,
         }
+    model_ids = set(list(queue_counts.keys()) + [c["model_id"] for c in containers.values()])
     return {
         "total_gpu_vram_mib": TOTAL_GPU_VRAM,
-        "pools": MANAGED_POOLS,
+        "pools": pools,
         "gpus": gpus_status,
-        "known_footprints_mib": known_footprints,
-        "active_containers": {name: state.__dict__ for name, state in active_containers.items()},
+        "known_footprints_mib": footprints,
+        "active_containers": containers,
         "queue_status": {
             model_id: {
-                "queue_depth": model_queue_counts.get(model_id, 0),
+                "queue_depth": queue_counts.get(model_id, 0),
                 "max_concurrent": GATEWAY_MAX_CONCURRENT,
                 "max_queue_size": GATEWAY_MAX_QUEUE_SIZE
             }
-            for model_id in set(list(model_queue_counts.keys()) + [c.model_id for c in active_containers.values()])
+            for model_id in model_ids
         }
     }
 
@@ -1137,7 +1183,8 @@ async def proxy_request(request: Request):
                         footprint = known_footprints.get(target_model_id)
 
                         if TOTAL_GPU_VRAM > 0:
-                            # POOL-BASED PLACEMENT (whole-card model; no TP, no co-location).
+                            # POOL-BASED PLACEMENT (whole-card by default; tensor-parallel and
+                            # co-location handled below).
                             # known_footprints: None = never seen (discovery), 0 = seen-but-unmeasurable
                             # sentinel, >0 = measured. is_discovery only when truly unseen.
                             is_discovery = footprint is None
@@ -1286,7 +1333,7 @@ async def proxy_request(request: Request):
                                     logging.warning(f"Could not measure footprint for {target_model_id} ({measured} MiB); "
                                                     f"keeping whole-card estimate {int(needed_per_gpu)} MiB.")
                                     known_footprints[target_model_id] = 0  # sentinel: seen but unmeasurable
-                                save_known_footprints()
+                                await save_known_footprints_async()
 
                         else: # Fallback if VRAM management is disabled
                             # Without VRAM management, only run one container at a time

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -258,6 +258,27 @@ def validate_tp_against_pools(configs: "dict[str, ModelConfig]", pools: "dict[st
                 )
 
 
+def validate_pools_visible(pools: "dict[str, list]", visible_uuids: "set") -> None:
+    """Fail fast if any configured GPU UUID isn't visible to nvidia-smi.
+
+    Runs at startup AFTER the GPU probe (the visible set is a runtime fact). Catches the common
+    typo in a long `GPU-xxxx...` UUID, instead of silently treating that GPU as having 0 VRAM
+    (which would make its pool unplaceable with only a log warning).
+    """
+    if not pools:
+        return
+    missing = []
+    for pool_name, uuids in pools.items():
+        for u in uuids:
+            if u not in visible_uuids:
+                missing.append(f"{u} (pool '{pool_name}')")
+    if missing:
+        raise ValueError(
+            "Configured GPU UUID(s) not visible to nvidia-smi: " + "; ".join(missing) +
+            f". Visible: {sorted(visible_uuids)}. Check pools/GATEWAY_GPU_UUID against `nvidia-smi -L`."
+        )
+
+
 def validate_colocate(configs: "dict[str, ModelConfig]", max_share: float = 0.9) -> None:
     """Validate co-location settings. Raises on a hard conflict; warns on a soft smell.
 

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -14,6 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 from config_loader import (  # noqa: E402
     resolve_model_configs, build_fallback_configs, resolve_pools,
     validate_model_pools, validate_tp_against_pools, validate_colocate,
+    validate_pools_visible,
 )
 
 # Mirrors app.builtin_model_defaults() with stock env-var defaults.
@@ -259,6 +260,19 @@ def test_validate_colocate_forbids_tp():
     else:
         raise AssertionError("expected ValueError for colocate + tp>1")
     print("ok: validate_colocate forbids TP")
+
+
+def test_validate_pools_visible():
+    pools = {"llm": ["GPU-a", "GPU-b"], "util": ["GPU-c"]}
+    validate_pools_visible(pools, {"GPU-a", "GPU-b", "GPU-c", "GPU-x"})  # all present -> ok
+    validate_pools_visible({}, set())  # no pools -> ok
+    try:
+        validate_pools_visible(pools, {"GPU-a", "GPU-c"})  # GPU-b missing
+    except ValueError as e:
+        assert "GPU-b" in str(e) and "not visible" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for a missing UUID")
+    print("ok: validate_pools_visible")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Stacked on #7 (base `placement-phase-3`). First of two hardening PRs that address the verified
implementation review (`docs/review-findings.md`). **Stage 1 = the fixes that don't touch the
placement decision block**, so they're low-risk and independently reviewable.

## Fixes
| # | Issue | Fix |
|---|---|---|
| **F6** | `extra_args` could override gateway-computed `--gpu-memory-utilization` / `--tensor-parallel-size` (defeats colocation cap / pool-validated TP) | `merge_extra_args` drops + warns on `GATEWAY_MANAGED_FLAGS` (`--model`, `--gpu-memory-utilization`, `--tensor-parallel-size`) |
| **F8/F11** | probe ran before pool resolution and used the pin → other pool GPUs unseen (`total=0`); one bad UUID could fail the whole probe; silent degradation | probe is now `count=-1` (sees all GPUs; pin no longer constrains it); new `validate_pools_visible()` **fail-fast** post-probe; `TOTAL_GPU_VRAM` recomputed from the managed set |
| **F10** | `/gateway/status` (sync, threadpool) iterated shared dicts unlocked → `RuntimeError: dict changed size` | `async` + snapshot under locks, response built from copies |
| **F15** | blocking `json.dump` on the event loop under locks | `save_known_footprints_async` via `run_in_executor` |
| **F16** | stale comments ("no TP/no co-location", pin wording) | corrected |

## Deferred to Stage 2 (next PR)
All the remaining findings edit the **placement decision block** that the Stage 2 concurrency
refactor rewrites wholesale — doing them now would mean editing that block twice. Moved together:
- **F1/F3/F4/F7/F13** — concurrency core (`LOADING/READY/STOPPING` state machine, single `state_lock`,
  reservation-as-entry, background reconciler).
- **F2/F9** — deterministic `effective_tp` + per-card `need_fn` + footprint re-key.
- **F5** — fold the `TOTAL_GPU_VRAM==0` bypass into the unified path.

*(The approved plan listed F2/F9/F5 in Stage 1; moved to Stage 2 for the reason above. Recorded in
`docs/review-findings.md`.)*

## Test plan
- `ast.parse` on all three modules.
- `tests/test_placement.py` 26/26; `tests/test_config_resolution.py` 14/14 (incl. new `validate_pools_visible`).
- Docker-stubbed smoke: denylist strips overrides + keeps non-managed flags; `gateway_status` is an async safe-snapshot; probe is `count=-1`; bad-UUID fail-fast fires.
- Not run on real hardware (consistent with the rest of the stack).

🤖 Generated with [Claude Code](https://claude.com/claude-code)