### PR TITLE
compose: parameterize model-config mount via HOST_CONFIG_DIR

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,8 +45,11 @@ services:
       # Mount a directory for data persistence (app will create files inside)
       - ${HOST_DATA_DIR:-./data}:/app/data
       - ${HOST_TEMP_DIR:-/tmp}:${VLLM_TEMP_DIR:-/tmp}
-      # Per-model configuration (read-only). Copy config/models.yaml.example -> config/models.yaml
-      - ./config:/app/config:ro
+      # Per-model configuration (read-only), mounted at /app/config (MODELS_CONFIG_FILE points here).
+      # Set HOST_CONFIG_DIR to an absolute host dir (e.g. /models/vllm-gateway/config) that contains
+      # your models.yaml — so the config can live on the host and be configured purely via env (no
+      # compose edit needed). Defaults to ./config in the stack dir for local/dev use.
+      - ${HOST_CONFIG_DIR:-./config}:/app/config:ro
 
     networks:
       - vllm_network


### PR DESCRIPTION
## Why

The Portainer deploy logs `No model config file at '/app/config/models.yaml'; using ALLOWED_MODELS_JSON fallback (0 model(s)): []` even though the host `models.yaml` is present and validates.

Root cause: `master`'s compose hardcoded the config mount as `- ./config:/app/config:ro`, so the gateway mounts the **repo clone's** `config/` (which only contains `models.yaml.example`) instead of the host directory holding the real `models.yaml`. The `HOST_CONFIG_DIR` parameterization landed on the stage3 branch *after* PR #12 merged, so it never reached `master`.

## What

Change the mount to:

```yaml
- ${HOST_CONFIG_DIR:-./config}:/app/config:ro
```

This lets the config live on the host and be selected purely via a Portainer stack env var (`HOST_CONFIG_DIR`) — no compose edit needed at deploy time (which Portainer can't do anyway). Defaults to `./config` for local/dev, so behavior is unchanged when the var is unset.

## Deploy

Set `HOST_CONFIG_DIR=/models/vllm-gateway/config` in the Portainer stack environment and redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)