### PR TITLE
worker: WORKER_LD_LIBRARY_PATH to bypass image cuda-compat shadow (CUDA 803)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,14 @@ services:
       GATEWAY_CONTAINER_NAME: ${GATEWAY_CONTAINER_NAME:-vllm_gateway}
       VLLM_CONTAINER_PREFIX: ${VLLM_CONTAINER_PREFIX:-vllm_server}
 
+      # --- WORKER CUDA / DRIVER ---
+      # Optional LD_LIBRARY_PATH applied to every vLLM worker container. Leave blank normally.
+      # Set it when the host NVIDIA driver is NEWER than the vLLM image's bundled cuda-compat lib
+      # (symptom: workers crash at startup with CUDA error 803 / "unsupported display driver / cuda
+      # driver combination"). Point it at the host driver libs the NVIDIA Container Toolkit mounts:
+      #   WORKER_LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
+      WORKER_LD_LIBRARY_PATH: ${WORKER_LD_LIBRARY_PATH:-}
+
       # --- PATHS (HOST) ---
       HOST_CACHE_DIR: ${HOST_CACHE_DIR:-/root/.cache/huggingface}
       HOST_TEMP_DIR: ${HOST_TEMP_DIR:-/tmp}

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -47,6 +47,15 @@ NVIDIA_UTILITY_IMAGE = os.getenv("NVIDIA_UTILITY_IMAGE", "nvidia/cuda:12.1.0-bas
 MEMORY_FOOTPRINT_FILE = os.getenv("MEMORY_FOOTPRINT_FILE", "/app/data/memory_footprints.json")
 VLLM_TEMP_DIR = os.getenv("VLLM_TEMP_DIR", "/tmp")
 
+# Optional LD_LIBRARY_PATH for the spawned vLLM worker containers. Leave unset for the normal
+# case (the image's bundled cuda-compat libcuda is correct when the host driver is OLDER than the
+# image's CUDA). Set it when the host driver is NEWER than the image's cuda-compat lib: the compat
+# libcuda then can't talk to the newer kernel module and CUDA init fails with error 803
+# (cudaErrorSystemDriverMismatch). Pointing the loader at the host driver libs the NVIDIA Container
+# Toolkit mounts at /usr/lib/x86_64-linux-gnu makes the worker use the real (host) libcuda, e.g.:
+#   WORKER_LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
+WORKER_LD_LIBRARY_PATH = os.getenv("WORKER_LD_LIBRARY_PATH", "").strip()
+
 # Path to the per-model YAML config. When present, it replaces ALLOWED_MODELS_JSON.
 MODELS_CONFIG_FILE = os.getenv("MODELS_CONFIG_FILE", "/app/config/models.yaml")
 
@@ -1005,6 +1014,9 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
                 "HUGGING_FACE_HUB_TOKEN": HF_TOKEN,
                 "VLLM_ALLOW_LONG_MAX_MODEL_LEN": "1",
                 "VLLM_CACHE_BUST": str(uuid.uuid4()),
+                # When set, override the loader path so the worker uses the host driver's libcuda
+                # instead of the image's bundled cuda-compat lib (see WORKER_LD_LIBRARY_PATH).
+                **({"LD_LIBRARY_PATH": WORKER_LD_LIBRARY_PATH} if WORKER_LD_LIBRARY_PATH else {}),
             },
             ipc_mode="host",
             device_requests=device_requests,


### PR DESCRIPTION
## Why

On a host whose NVIDIA driver is **newer** than the vLLM image's bundled `cuda-compat` lib, every spawned worker crashes at startup with:

```
RuntimeError: Unexpected error from cudaGetDeviceCount() ... Error 803:
system has unsupported display driver / cuda driver combination
```

Root cause (verified on hardware): `ldconfig` inside `vllm/vllm-openai:v0.16.0` resolves `libcuda.so.1 → /usr/local/cuda-12.9/compat/libcuda.so.575.57.08`. On a host running driver **595.71.05 / CUDA 13.2**, that 575 compat `libcuda` can't talk to the newer kernel module → error 803. `nvidia-smi` (NVML) and `torch.cuda.device_count()` still work because they don't create a real CUDA context, which is why the failure only shows at engine init.

Confirmed fix: pointing the loader at the host driver libs the NVIDIA Container Toolkit mounts at `/usr/lib/x86_64-linux-gnu` makes the worker use the real (host) `libcuda`:

```
docker run --rm --gpus '"device=GPU-..."' -e LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu \
  --entrypoint python3 vllm/vllm-openai:v0.16.0 -c "import torch; print(torch.cuda.get_device_name(0))"
# -> NVIDIA GeForce RTX 3090
```

## What

- `app.py`: new `WORKER_LD_LIBRARY_PATH` env var; when set, injected as `LD_LIBRARY_PATH` on every spawned vLLM worker container.
- `docker-compose.yml`: pass-through `WORKER_LD_LIBRARY_PATH: ${WORKER_LD_LIBRARY_PATH:-}` so it's configurable purely via the Portainer stack env (no compose edit at deploy).

Unset by default → the normal forward-compat case (host driver **older** than the image's CUDA, where the compat lib is correct) is completely unaffected.

## Deploy

Set in the Portainer stack env and redeploy:
```
WORKER_LD_LIBRARY_PATH=/usr/lib/x86_64-linux-gnu:/usr/local/nvidia/lib64:/usr/local/cuda/lib64
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)