### PR TITLE
Budget placement mode: per-GPU VRAM packing with measured accounting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -58,12 +58,28 @@ VLLM_IMAGE=vllm/vllm-openai:v0.10.2
 # Default: 0.90 (90% of available GPU memory)
 VLLM_GPU_MEMORY_UTILIZATION=0.90
 
+# --- Placement mode -------------------------------------------------------
+# budget (default): GPU_BUDGET_FRACTION is a per-GPU TOTAL cap; each model is sized to only
+#   what it needs (weights + KV for max_model_len x max_num_seqs + overhead) and many models
+#   pack per card. REQUIRES max_model_len > 0 for every model (fails fast otherwise).
+# whole_card: legacy — one model fills its card at its util; swap via LRU eviction.
+PLACEMENT_MODE=budget
+# Per-GPU budget cap (fraction of each card the gateway may fill in total across all its models).
+# Defaults to VLLM_GPU_MEMORY_UTILIZATION.
+GPU_BUDGET_FRACTION=0.90
+# Need-estimate cushion: (weights + KV) * factor + a fixed per-card margin (MiB). Bias generous;
+# the launch util cap means an under-estimate only fails that model's own startup, never a peer.
+BUDGET_OVERHEAD_FACTOR=1.1
+BUDGET_OVERHEAD_MIB=1024
+
 # Global maximum model length (context window)
 # Set to 0 to use model's default. Otherwise limits all models to this value.
 # Default: 0
 VLLM_MAX_MODEL_LEN_GLOBAL=0
 
-# Maximum number of concurrent sequences
+# Maximum number of concurrent sequences (default fallback; override per-model with max_num_seqs).
+# NOTE: this is now a real per-model setting (must be >= 1) and bounds KV-cache need in budget mode.
+# A value of 0 no longer means "omit the flag" — it is coerced to 16.
 # Default: 16
 VLLM_MAX_NUM_SEQS=16
 

--- a/README.md
+++ b/README.md
@@ -198,6 +198,65 @@ models:
   through this swapping gateway. The gateway's `util` pool can still place small models on the same
   A2000 because it reads the card's real free VRAM. See `/gateway/status` for per-GPU pool/usage/residents.
 
+## Placement modes
+
+`PLACEMENT_MODE` controls how the gateway fits models onto a card.
+
+### `budget` (default)
+
+`GPU_BUDGET_FRACTION` becomes a **per-GPU total cap** (fraction of each card the gateway may fill
+across *all* its models). Each model is launched sized to **only what it needs** — its weights plus
+the KV cache for its `max_model_len` × `max_num_seqs`, plus a safety cushion — and the gateway packs
+**multiple models onto one card** until the budget is full. When the budget can't fit a new model it
+evicts idle models LRU, or returns **503** rather than over-commit.
+
+Why this is safe: `--gpu-memory-utilization` is a hard fraction of total card memory, so launching a
+model at `util = need / card_total` makes it **physically unable** to exceed its budgeted share. An
+under-estimate can therefore only fail *that* model's own startup — it can never OOM a co-resident.
+Estimates are biased generous via `BUDGET_OVERHEAD_FACTOR` / `BUDGET_OVERHEAD_MIB`.
+
+**Ground-truth accounting.** The sizing estimate (weights from HF metadata + sliding-window-aware KV)
+only picks the launch util. After a model is READY the gateway measures its **actual** per-process
+VRAM (`nvidia-smi` compute-apps attributed to the container) and uses *that* as the footprint for
+placement math — so the gateway's view always matches reality, including the effects of quantization,
+sliding-window attention, and KV dtype. Each footprint is stamped with a **signature**
+(mode + `max_model_len` + `max_num_seqs` + tensor-parallel + util basis) and is reused only when that
+signature matches — so a mode switch or a config change **re-measures automatically** instead of
+trusting a stale value.
+
+**Restrictions in budget mode.** Memory-affecting flags must be set via the structured keys, not
+`extra_args`: `--max-model-len`, `--max-num-seqs`, `--kv-cache-dtype`, `--gpu-memory-utilization` in
+`extra_args` are rejected at startup (they would diverge from the gateway's sizing). Models the gateway
+can't auto-size (GGUF, or no readable HF config) load **alone once** at their per-model
+`gpu_memory_utilization`, are measured, then pack at that measured size on later requests — so set that
+value to the share you want such a model to take.
+
+**Requirement:** every model must set `max_model_len > 0` (and ideally a modest `max_num_seqs`),
+because vLLM's KV-cache need is otherwise unbounded. The gateway **fails fast at startup** if a model
+omits it. The `colocate` flag is ignored in this mode (packing is universal).
+
+**Tradeoff:** a lone model is sized to its need and leaves the rest of the card idle (so others can
+join). That caps single-model peak throughput (smaller KV pool) in exchange for density. If you run
+one model at a time and want maximum throughput, use `whole_card`.
+
+```yaml
+# config/models.yaml — two models share one 24 GB card under budget mode
+defaults: { pool: llm, max_num_seqs: 8 }
+models:
+  qwen9b:  { repo: cyankiwi/Qwen3.5-9B-AWQ-4bit,    quantization: awq, max_model_len: 32768 }
+  gemma:   { repo: cyankiwi/gemma-4-E4B-it-AWQ-INT4, quantization: awq, max_model_len: 32768 }
+```
+
+### `whole_card`
+
+The legacy behavior: each model fills its card at its own `gpu_memory_utilization`, and the gateway
+swaps models via LRU eviction when a different model is requested. `colocate: true` lets small models
+share a card here. No `max_model_len` requirement. Set `PLACEMENT_MODE=whole_card` to keep this.
+
+> **Upgrade note:** the default changed to `budget`. A deployment using the legacy
+> `ALLOWED_MODELS_JSON` (no per-model `max_model_len`) will now refuse to start until you either set
+> `max_model_len` per model (via `models.yaml`) or set `PLACEMENT_MODE=whole_card`.
+
 ## Configuration
 
 All configuration is done via environment variables, making it easy to deploy with Portainer, Kubernetes, or directly from GitHub.
@@ -234,6 +293,15 @@ The `.env` file will be automatically loaded by Docker Compose.
 | `VLLM_MAX_NUM_SEQS` | `16` | Maximum concurrent sequences |
 | `VLLM_TENSOR_PARALLEL_SIZE` | `1` | Number of GPUs to split model across |
 | `VLLM_PORT` | `8000` | Internal port used by vLLM containers |
+
+#### Placement Settings
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PLACEMENT_MODE` | `budget` | `budget` (pack many models per card under a cap) or `whole_card` (legacy LRU swap). See [Placement modes](#placement-modes). |
+| `GPU_BUDGET_FRACTION` | `VLLM_GPU_MEMORY_UTILIZATION` | Per-GPU total VRAM cap (fraction) the gateway may fill across all its models in `budget` mode |
+| `BUDGET_OVERHEAD_FACTOR` | `1.1` | Multiplier on (weights + KV) when estimating a model's need |
+| `BUDGET_OVERHEAD_MIB` | `1024` | Fixed per-card margin (MiB) added to each model's need estimate |
 
 #### Networking Settings
 

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -7,6 +7,26 @@
 #
 # Resolution precedence per setting:
 #   per-model entry  >  defaults block  >  built-in default (the old env var)
+#
+# --- Placement mode (PLACEMENT_MODE env var) -------------------------------
+# 'budget' (DEFAULT): treat GPU_BUDGET_FRACTION as a per-GPU TOTAL cap and size each
+#   model to ONLY what it needs (weights + KV for its max_model_len x max_num_seqs +
+#   overhead), packing MANY models per card until the budget is full. In this mode
+#   EVERY model MUST set max_model_len > 0 (the gateway fails fast otherwise, because
+#   vLLM's KV-cache need is unbounded without it). The 'colocate' flag is ignored
+#   (packing is universal). Tune each model's max_num_seqs to bound its KV footprint.
+#   - After a model loads, the gateway records its ACTUAL VRAM (per-process measurement)
+#     as the footprint, so accounting is ground-truth. The footprint is stamped with a
+#     signature (mode + max_model_len + max_num_seqs + tp + util) and re-measured whenever
+#     you change any of those — no stale sizing after a config edit.
+#   - Memory-affecting flags must come from the structured keys (max_model_len,
+#     max_num_seqs), NOT extra_args: --max-model-len / --max-num-seqs / --kv-cache-dtype /
+#     --gpu-memory-utilization in extra_args are rejected at startup in budget mode.
+#   - Un-estimable models (GGUF, or no readable HF config) can't be auto-sized: they load
+#     ALONE once at their per-model gpu_memory_utilization, are measured, then pack at that
+#     measured size. So for those, set gpu_memory_utilization to the share you want them to take.
+# 'whole_card': legacy behavior — one model fills its card at gpu_memory_utilization
+#   and the gateway swaps models via LRU eviction. 'colocate' applies here.
 
 # --- GPU pools (optional, multi-GPU) ---------------------------------------
 # Declare the GPUs this gateway manages and group them into named pools. Get the
@@ -34,8 +54,10 @@ pools:
 
 defaults:                      # optional; applied to every model unless overridden
   pool: llm                    # default pool for models that don't set one
-  gpu_memory_utilization: 0.90 # 0 < x <= 1
-  max_model_len: 0             # 0 = use the model's native max (omit the flag)
+  gpu_memory_utilization: 0.90 # whole_card mode: per-model card share. budget mode: unused for
+                               # sizing (GPU_BUDGET_FRACTION is the cap); still the discovery util.
+  max_model_len: 0             # 0 = native max (whole_card). budget mode REQUIRES > 0 per model.
+  max_num_seqs: 16             # max concurrent sequences (--max-num-seqs); bounds KV need in budget mode
   tensor_parallel_size: 1
   quantization: null           # awq | gptq | fp8 | null
   dtype: auto                  # auto | float16 | bfloat16 | ...
@@ -83,6 +105,24 @@ models:                        # required, non-empty
     pool: llm
     colocate: true
     gpu_memory_utilization: 0.45
+
+  # --- Budget-mode packing (PLACEMENT_MODE=budget) -------------------------
+  # These two pack onto ONE 24 GB 3090 at the same time. Each is sized to weights + the KV
+  # for its (max_model_len x max_num_seqs) + overhead; the gateway adds them up and keeps the
+  # total under GPU_BUDGET_FRACTION x 24 GB. No colocate flag needed — packing is automatic.
+  # Keep max_model_len / max_num_seqs modest to fit more models per card.
+  packed-9b-awq:
+    repo: cyankiwi/Qwen3.5-9B-AWQ-4bit
+    quantization: awq
+    pool: llm
+    max_model_len: 32768
+    max_num_seqs: 8
+  packed-gemma-e4b:
+    repo: cyankiwi/gemma-4-E4B-it-AWQ-INT4
+    quantization: awq
+    pool: llm
+    max_model_len: 32768
+    max_num_seqs: 8
 
   # A large model forced across both 3090s with tensor parallel. tensor_parallel_size must
   # not exceed the GPUs declared in the pool (validated at startup), and the pool must be

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,15 @@ services:
       # Path to the per-model config (mounted read-only at /app/config below).
       MODELS_CONFIG_FILE: ${MODELS_CONFIG_FILE:-/app/config/models.yaml}
 
+      # --- PLACEMENT ---
+      # budget (default): GPU_BUDGET_FRACTION is a per-GPU TOTAL cap; each model is sized to only
+      #   what it needs and many models pack per card. Requires max_model_len > 0 for every model.
+      # whole_card: legacy one-model-per-card with LRU swap. See config/models.yaml.example.
+      PLACEMENT_MODE: ${PLACEMENT_MODE:-budget}
+      GPU_BUDGET_FRACTION: ${GPU_BUDGET_FRACTION:-0.90}
+      BUDGET_OVERHEAD_FACTOR: ${BUDGET_OVERHEAD_FACTOR:-1.1}
+      BUDGET_OVERHEAD_MIB: ${BUDGET_OVERHEAD_MIB:-1024}
+
       # --- GPU PINNING / POOLS ---
       # For multi-GPU, declare a 'pools:' section in models.yaml (one gateway manages
       # several GPUs and places each model on a GPU in its pool). For a single GPU, leave

--- a/docs/review-budget-mode-findings.md
+++ b/docs/review-budget-mode-findings.md
@@ -1,0 +1,166 @@
+# Review findings — budget placement mode (Phase 4) — RE-VERIFIED
+
+> **Status (Phase 5 hardening applied).** All confirmed findings below are now addressed:
+> - **B1** weights via `HfApi().model_info` (single-file + sharded + gated) — `gateway/app.py:estimate_weight_bytes`.
+> - **B4** sliding-window-aware KV (`_sliding_window_spec` + extended `placement.kv_cache_mib`) — ~5× tighter for Gemma 3.
+> - **B2** footprints stamped with a `signature` (mode + max_model_len + max_num_seqs + tp + util); reused only on match (`placement.signature_matches`) → no cross-mode / stale reuse.
+> - **B3** memory-affecting `extra_args` rejected at startup in budget mode (`config_loader.validate_extra_args_budget`).
+> - **B5** footprint is now the **measured** per-process VRAM (`measure_model_vram` / `placement.attribute_vram`), not the reserve estimate → accounting is ground-truth.
+> - **B6** `VLLM_MAX_NUM_SEQS=0` coerced to 16 (no startup break).
+> - **B7** un-estimable models load sole-occupant once, are measured, then pack at the measured size.
+> - **B15** `/gateway/status` now exposes `placement_mode`, per-GPU `budget_mib`, and per-model measured footprints.
+> - **B8/B16** config.json fetched once (cached); stale comment fixed.
+> See the updated plan and `tests/test_placement.py` / `tests/test_config_resolution.py`.
+
+
+Re-review of `PLACEMENT_MODE=budget`. Every finding below was re-checked against the actual code;
+several from the first pass were **overstated and are corrected here**. Documentation only — nothing
+is fixed. The focus is on what can actually happen in this deployment (single-GPU pin, AWQ/safetensors
+`cyankiwi/*` + gemma models, budget mode), not theoretical corners.
+
+## The key safety property (verified, and it holds)
+
+`--gpu-memory-utilization` is in `GATEWAY_MANAGED_FLAGS` (app.py:894), so `extra_args` cannot override
+it. In budget mode each model launches at `effective_util = min(GPU_BUDGET_FRACTION, budget_need/total)`,
+and `effective_util × total ≤ budget_need = reserve_amt`. vLLM physically cannot exceed
+`effective_util × total`, so **it always takes ≤ what the gateway reserved.**
+
+Consequence: **in pure budget mode a neighbor model can never be OOM'd**, no matter how wrong the need
+estimate is or what's in `extra_args`. A bad estimate only starves or fails *that* model's own startup.
+This is the strong guarantee, and it is real. The OOM-flavored findings from the first pass survive
+**only** on the non-budget launch paths (whole_card, and the budget-discovery fallback), where
+`effective_util = None` and vLLM instead uses the configured `gpu_memory_utilization` uncapped.
+
+Concurrency/lifecycle invariants (G1–G10/F1): re-confirmed intact (no I/O under `state_lock`, clean
+LOADING→READY→STOPPING, no new orphan path).
+
+---
+
+## CONFIRMED real and relevant to this deployment
+
+### B1 — Single-file `model.safetensors` (no shard index) → model loads whole-card, never packs
+**Verified:** `estimate_weight_bytes` (app.py:814) fetches **only** `model.safetensors.index.json`. A model
+shipped as one `model.safetensors` (no index — common for small/quantized models) gets a 404 there and
+returns `None`. `estimate_model_need_mib` then returns `None`, so `_ensure_started` takes the
+`budget_discovery` path: `effective_util=None`, `need_fn = util*g.total` → the model loads **whole-card**
+and is discovery-measured at its configured `gpu_memory_utilization`. On reload the measured (~whole-card)
+value is reused, so it **never packs**.
+
+**Why it matters here:** your smaller AWQ targets (e.g. `gemma-4-E4B`, ~2–3 GB) are plausibly single-file
+→ this silently defeats packing for exactly the model the feature was meant to co-locate. This is the
+single most likely finding to bite in practice.
+
+**Partial workaround that exists today (undocumented):** set a low per-model `gpu_memory_utilization`
+(e.g. 0.45) on such a model; the discovery measurement is then taken at that util, so it packs partially.
+
+### B4 — KV formula ignores sliding-window attention → over-sizes Gemma 3, hurts packing
+**Verified:** `kv_cache_mib` (placement.py) multiplies over **all** layers at **full** `max_model_len`;
+`get_model_kv_spec` never reads `sliding_window` or the local/global layer pattern. Gemma 3 uses a
+~1024 sliding window on ~5 of every 6 layers, so the true resident KV is a small fraction of the full
+figure — the estimate can be ~5–6× too large.
+
+**Why it matters here:** you run gemma models, and `google/gemma-3-4b-it` is the first example in the
+config. The over-estimate is **safe** (it only over-reserves, never OOMs), but it directly shrinks how
+many models pack per card — undercutting the feature for these exact models. Mistral sliding-window
+variants are affected the same way.
+
+### B2(a) — Stale footprints reused without invalidation (deterministic)
+**Verified:** `known_footprints` is keyed by **repo only** and stores `effective_util`/`measured_at` but
+**not the placement mode or the `max_model_len`/`max_num_seqs` it was sized for**. `learned_mib` is read
+unconditionally and reused as the GGUF/un-estimable need (app.py ~1467) and as the whole_card need
+(~1475).
+
+**Real, deterministic effects (no timing window needed):**
+- On **upgrade** from a whole_card-era deployment, `memory_footprints.json` already holds whole-card
+  measurements. For estimable sharded-safetensors models budget mode recomputes and ignores them (fine),
+  but for **single-file (B1) or GGUF** models it reuses the stale whole-card value → they never pack.
+- Changing a model's `max_model_len`/`max_num_seqs` does **not** invalidate a persisted record for the
+  un-estimable models, so their size won't track the new config.
+
+This is the existing review note **A1** (footprints not keyed by placement context), now load-bearing.
+
+---
+
+## CONFIRMED but conditional (real, narrower trigger)
+
+### B2(b) — whole_card after budget can over-commit (the one real neighbor-OOM vector)
+If you run budget mode (persisting *tight* footprints), then switch to `PLACEMENT_MODE=whole_card`
+without clearing the file, model A is sized for placement at its tight `learned_mib` yet launched
+uncapped (`effective_util=None` → configured 0.90 util → ~whole card). Its `vram_footprint` (= the tight
+reserve) under-floors `ready_footprint`. If a second model's placement snapshot is taken while A is still
+LOADING (so nvidia-smi hasn't yet caught up to A's real usage), the gateway can believe the card has room
+and place B → genuine **OOM** when both finish allocating.
+
+**Honest scope:** requires (1) a budget→whole_card switch without clearing footprints, and (2) two models
+loading concurrently in that window. Not a steady-state hazard (once A is READY, `used_smi` reflects
+reality and the floor is moot). Real, but conditional and avoidable by clearing footprints on a mode
+switch. This is the **only** confirmed neighbor-OOM path.
+
+### B7 — GGUF models behave whole-card in budget mode (and evict peers to self-measure)
+Same `None`-estimate path as B1. First load reserves ~whole card and `select_placement` **evicts
+co-resident packed models** just to measure one GGUF model; on reload it stays whole-card-sized. Only
+relevant if you actually run GGUF models (your current set is AWQ safetensors, so N/A today — but the
+gateway advertises GGUF support, so worth knowing).
+
+### B3 — `extra_args` memory flags diverge from the estimate → model's own startup may fail (NOT a neighbor OOM)
+**Corrected from the first pass.** `--max-model-len`/`--max-num-seqs`/`--kv-cache-dtype` in `extra_args`
+aren't managed, so the launched config can differ from the structured values used in the estimate. But
+because the util cap **is** managed, the consequence is bounded: e.g. `max_model_len: 4096` (tight util)
++ `extra_args: ["--max-model-len","32768"]` → vLLM is given the small KV budget but asked for 32k context
+and **fails its own startup** with the "KV cache insufficient" error you already saw — it cannot OOM a
+neighbor. `--enable-prefix-caching` (shipped for `qwen2.5-coder`) does **not** increase VRAM beyond the
+util budget, so it's a non-issue. Real footgun (silent own-startup failure / mis-size), Medium at most,
+no OOM.
+
+### B6 — `VLLM_MAX_NUM_SEQS=0` now fails startup
+**Verified** real: the env default feeds `max_num_seqs` whose validator requires `>= 1`, so `0`
+(previously the "omit the flag" sentinel) now raises at startup. **But** the default is 16 and nothing
+documents 0 as meaningful, so it's unlikely anyone set it. Clean fail-fast, not silent. Low likelihood;
+note in the upgrade docs and move on.
+
+---
+
+## Real but minor (keep in mind, low impact)
+
+- **B5** — `reserve_amt = budget_need` vs `effective_util` clamped at the cap: when `budget_need/total ≥
+  GPU_BUDGET_FRACTION` the reservation over-counts what vLLM took (under-packs). Conservative, no harm;
+  the code comment "vLLM takes ONLY this need" is inexact at the cap.
+- **B8** — `config.json` is fetched twice per cold start (`get_model_max_len` + `get_model_kv_spec`) and
+  weights up to twice. A few redundant GETs; negligible vs a multi-minute load.
+- **B9** — KV estimate uses configured `max_model_len`, not capped to native; over-reserves when
+  configured > native (safe).
+- **B12** — `get_model_kv_spec`'s `text_config` heuristic is best-effort; multimodal configs that nest the
+  LM under a different key, or omit the fields, return `None` → discovery → whole-card (compounds B1).
+  Worth confirming the gemma multimodal configs expose the fields under `text_config` as expected.
+- **B15** — `/gateway/status` doesn't expose `PLACEMENT_MODE`, the per-GPU budget cap, or each model's
+  effective need/util — budget-mode packing is hard to observe operationally.
+- **B16** — stale comment in `_ensure_started` (record shape omits `effective_util`).
+- **B17** — design note: for estimable models the need is recomputed every cold start, so the persisted
+  `per_gpu_mib` is display-only; `learned_mib` is load-bearing only for the un-estimable (B1/GGUF) path.
+
+---
+
+## Considered and dropped as theoretical (won't happen in practice)
+
+- `head_dim` fallback wrong (B10): only if `config.json` omits `head_dim` AND the model uses a
+  non-standard one — modern configs include it.
+- KV-dtype guessed as 2 bytes when fp8 KV set via `extra_args` (B11): rare config, and it only
+  over-reserves (safe).
+- Mamba/SSM/hybrid KV formula invalid (B13): not in this model set.
+- `budget_free` negative on mid-flight budget reduction (B18): handled by the eviction math; not a real
+  workflow.
+- `round(util,4)` → 0 for a sub-2.4 MiB need (B19): impossible — `BUDGET_OVERHEAD_MIB` (1024) floors
+  every need far above that.
+
+---
+
+## Bottom line
+
+- **No neighbor-OOM risk in pure budget mode** — the util cap guarantees it. The one real OOM path (B2b)
+  needs a budget→whole_card switch with a stale footprints file and a concurrent load.
+- **The findings that will actually bite you:** **B1** (single-file safetensors → no packing) and **B4**
+  (sliding-window over-sizing on gemma) — both quietly defeat packing for your exact models, and both
+  fail *safe* (over-reserve / load-alone), so you'd see "models still swapping / not co-residing" rather
+  than a crash. **B2(a)** matters the moment you reuse an existing `memory_footprints.json` across the
+  mode change.
+- Everything else is either conditional on workflows you may not hit (B2b, B6, B7) or genuinely minor.

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -3,6 +3,7 @@ import asyncio
 import httpx
 import docker
 import json
+import math
 import time
 import logging
 import uuid
@@ -14,13 +15,13 @@ from docker.types import DeviceRequest
 from docker.errors import NotFound, APIError
 from dataclasses import dataclass, field
 from enum import Enum
-from huggingface_hub import hf_hub_download, list_repo_files
+from huggingface_hub import hf_hub_download, list_repo_files, HfApi
 import yaml
 import placement
 from config_loader import (
     ModelConfig, resolve_model_configs, build_fallback_configs,
     resolve_pools, validate_model_pools, validate_tp_against_pools, validate_colocate,
-    validate_pools_visible, migrate_footprints,
+    validate_pools_visible, validate_budget_mode, validate_extra_args_budget, migrate_footprints,
 )
 
 # --- Logging Configuration ---
@@ -95,6 +96,20 @@ COLOCATE_MARGIN_MIB = int(os.getenv("COLOCATE_MARGIN_MIB", "1024"))
 COLOCATE_WEIGHT_OVERHEAD = float(os.getenv("COLOCATE_WEIGHT_OVERHEAD", "1.15"))
 COLOCATE_MAX_SHARE = float(os.getenv("COLOCATE_MAX_SHARE", "0.9"))
 
+# --- Placement mode (Phase 4) ---
+# 'budget'     : size each model to weights+KV+overhead and pack many models per card up to a
+#                per-GPU budget cap. Requires max_model_len > 0 per model (bounds the KV need).
+# 'whole_card' : legacy behavior — one model fills the card at its util; swap via LRU eviction.
+PLACEMENT_MODE = os.getenv("PLACEMENT_MODE", "budget").strip().lower()
+# Per-GPU budget: fraction of each card the gateway may fill IN TOTAL across all its models.
+# Defaults to the legacy global utilization so an existing deployment keeps the same ceiling.
+GPU_BUDGET_FRACTION = float(os.getenv("GPU_BUDGET_FRACTION", VLLM_GPU_MEMORY_UTILIZATION))
+# Need-estimate cushion: (weights + KV) * factor + a fixed per-card margin (CUDA context, cudagraphs).
+# Bias generous — the launch util cap means an under-estimate only fails THIS model's own startup,
+# never a co-resident, so erring large is safe.
+BUDGET_OVERHEAD_FACTOR = float(os.getenv("BUDGET_OVERHEAD_FACTOR", "1.1"))
+BUDGET_OVERHEAD_MIB = int(os.getenv("BUDGET_OVERHEAD_MIB", "1024"))
+
 # Timeout configuration (in seconds)
 GATEWAY_REQUEST_TIMEOUT = int(os.getenv("GATEWAY_REQUEST_TIMEOUT", "300"))  # Total request timeout (default 5 minutes)
 GATEWAY_CONNECT_TIMEOUT = int(os.getenv("GATEWAY_CONNECT_TIMEOUT", "10"))  # Connection establishment timeout
@@ -110,6 +125,14 @@ def validate_config():
         raise ValueError(f"GATEWAY_REQUEST_TIMEOUT must be > 0, got {GATEWAY_REQUEST_TIMEOUT}")
     if GATEWAY_CONNECT_TIMEOUT <= 0:
         raise ValueError(f"GATEWAY_CONNECT_TIMEOUT must be > 0, got {GATEWAY_CONNECT_TIMEOUT}")
+    if PLACEMENT_MODE not in ("budget", "whole_card"):
+        raise ValueError(f"PLACEMENT_MODE must be 'budget' or 'whole_card', got {PLACEMENT_MODE!r}")
+    if not (0 < GPU_BUDGET_FRACTION <= 1):
+        raise ValueError(f"GPU_BUDGET_FRACTION must be in (0, 1], got {GPU_BUDGET_FRACTION}")
+    if BUDGET_OVERHEAD_FACTOR < 1:
+        raise ValueError(f"BUDGET_OVERHEAD_FACTOR must be >= 1, got {BUDGET_OVERHEAD_FACTOR}")
+    if BUDGET_OVERHEAD_MIB < 0:
+        raise ValueError(f"BUDGET_OVERHEAD_MIB must be >= 0, got {BUDGET_OVERHEAD_MIB}")
 
     if GATEWAY_MAX_QUEUE_SIZE > 10000:
         logging.warning(f"GATEWAY_MAX_QUEUE_SIZE is very large ({GATEWAY_MAX_QUEUE_SIZE}). This may cause memory issues.")
@@ -397,6 +420,68 @@ async def get_used_vram() -> float:
         return 0.0
     return float(_managed_vram(gpus, "used"))
 
+async def get_compute_apps_vram() -> "list[tuple]":
+    """Per-process GPU memory: list of (gpu_uuid, host_pid, used_mib) for every compute process.
+
+    Same probe-container pattern as get_gpu_vram (sees all GPUs). PIDs are HOST pids, which line up
+    with `docker top` / container State.Pid. Returns [] when compute-apps is unsupported/empty
+    (older drivers, MIG) so the caller falls back to delta measurement."""
+    output = await run_nvidia_smi_in_container(
+        ["nvidia-smi", "--query-compute-apps=gpu_uuid,pid,used_memory", "--format=csv,noheader,nounits"]
+    )
+    rows = []
+    for line in output.splitlines():
+        parts = [p.strip() for p in line.split(",")]
+        if len(parts) != 3:
+            continue
+        guid, pid, mib = parts
+        if guid and pid.isdigit():
+            rows.append((guid, int(pid), _parse_float(mib)))  # mib is "[N/A]" sometimes -> 0.0
+    return rows
+
+async def container_host_pids(container) -> set:
+    """Host PIDs of every process in a container (covers vLLM's EngineCore worker children).
+
+    Uses `docker top` (host-PID view, independent of the container's PID namespace) plus the
+    container's init PID. Returns an empty set on failure (caller falls back)."""
+    pids = set()
+    try:
+        await run_in_executor(container.reload)
+        init_pid = container.attrs.get("State", {}).get("Pid")
+        if init_pid:
+            pids.add(int(init_pid))
+        top = await run_in_executor(container.top)
+        titles = (top or {}).get("Titles") or []
+        procs = (top or {}).get("Processes") or []
+        pid_idx = titles.index("PID") if "PID" in titles else 1
+        for row in procs:
+            try:
+                pids.add(int(row[pid_idx]))
+            except (ValueError, IndexError, TypeError):
+                continue
+    except Exception as e:
+        logging.warning(f"Could not enumerate container PIDs: {e}")
+    return pids
+
+async def measure_model_vram(container_name: str, gpu_uuids: list) -> "float | None":
+    """Ground-truth VRAM (MiB) actually used by a model's container across its gpu_uuids, via
+    per-process attribution (nvidia-smi compute-apps -> the container's host PIDs). Returns None when
+    attribution is unavailable (no compute-apps support, PID mapping empty, or zero match) so the
+    caller can fall back to delta measurement."""
+    try:
+        container = await run_in_executor(docker_client.containers.get, container_name)
+        pids = await container_host_pids(container)
+        if not pids:
+            return None
+        rows = await get_compute_apps_vram()
+        if not rows:
+            return None
+        mib = placement.attribute_vram(rows, pids, gpu_uuids or [])
+        return mib if mib > 0 else None
+    except Exception as e:
+        logging.warning(f"Per-process VRAM attribution failed for {container_name}: {e}")
+        return None
+
 DEFAULT_POOL = "_default"  # implicit pool used in the single-pool / backward-compatible cases
 
 def resolve_managed_pools():
@@ -589,6 +674,9 @@ def builtin_model_defaults() -> dict:
         "gpu_memory_utilization": float(VLLM_GPU_MEMORY_UTILIZATION),
         "max_model_len": VLLM_MAX_MODEL_LEN_GLOBAL,
         "tensor_parallel_size": int(VLLM_TENSOR_PARALLEL_SIZE),
+        # A non-positive VLLM_MAX_NUM_SEQS used to mean "omit the flag"; max_num_seqs is now a real
+        # per-model setting (>= 1) and bounds KV need in budget mode, so coerce 0/invalid to 16.
+        "max_num_seqs": (int(VLLM_MAX_NUM_SEQS) if int(VLLM_MAX_NUM_SEQS) >= 1 else 16),
         "quantization": None,
         "dtype": "auto",
         "inactivity_timeout": VLLM_INACTIVITY_TIMEOUT,
@@ -619,6 +707,8 @@ def load_model_configs() -> "tuple[dict, dict]":
         validate_model_pools(configs, pools)  # fail fast on a model referencing an undeclared pool
         validate_tp_against_pools(configs, pools)  # fail fast if tensor_parallel_size > pool GPU count
         validate_colocate(configs, COLOCATE_MAX_SHARE)  # fail fast on colocate+TP; warn on high share
+        validate_budget_mode(configs, PLACEMENT_MODE)  # fail fast: budget mode needs max_model_len > 0
+        validate_extra_args_budget(configs, PLACEMENT_MODE)  # fail fast: no memory flags in extra_args
         logging.info(f"Loaded {len(configs)} model(s) from {MODELS_CONFIG_FILE}: {list(configs)}")
         if pools:
             logging.info(f"Declared GPU pools: { {p: len(u) for p, u in pools.items()} }")
@@ -631,6 +721,8 @@ def load_model_configs() -> "tuple[dict, dict]":
 
     allowed = load_allowed_models()
     configs = build_fallback_configs(allowed, builtins)
+    validate_budget_mode(configs, PLACEMENT_MODE)  # fail fast: budget mode needs max_model_len > 0
+    validate_extra_args_budget(configs, PLACEMENT_MODE)  # fail fast: no memory flags in extra_args
     logging.info(f"No model config file at '{MODELS_CONFIG_FILE}'; using ALLOWED_MODELS_JSON fallback "
                  f"({len(configs)} model(s)): {list(configs)}")
     return configs, {}
@@ -750,41 +842,77 @@ async def hf_repo_exists(repo_id: str) -> bool:
     except Exception:
         return False
 
+# Process-lifetime cache of parsed config.json by URL (a repo's config is immutable), so
+# get_model_max_len and get_model_kv_spec don't double-fetch the same file per cold start.
+_config_json_cache: "dict[str, dict | None]" = {}
+
+def _config_url_for(model_id: str, tokenizer_repo: "str | None" = None) -> "str | None":
+    """The config.json URL for a model (GGUF -> its base/tokenizer repo). None if unresolvable."""
+    if is_gguf_model(model_id):
+        path = tokenizer_repo or extract_tokenizer_from_gguf_path(model_id)
+        return f"https://huggingface.co/{path}/raw/main/config.json" if path else None
+    return f"https://huggingface.co/{model_id}/raw/main/config.json"
+
+async def _fetch_config_json(config_url: str) -> "dict | None":
+    """Fetch + cache a config.json. Returns the parsed dict, or None on any failure."""
+    if config_url in _config_json_cache:
+        return _config_json_cache[config_url]
+    cfg = None
+    try:
+        resp = await http_client.get(config_url, follow_redirects=True, timeout=httpx.Timeout(10.0))
+        resp.raise_for_status()
+        parsed = resp.json()
+        cfg = parsed if isinstance(parsed, dict) else None
+    except Exception as e:
+        logging.warning(f"Could not fetch {config_url}: {e}")
+    _config_json_cache[config_url] = cfg
+    return cfg
+
 async def get_model_max_len(model_id: str) -> int:
     """Fetches the model's config.json from Hugging Face to find its max length."""
-    # For GGUF models, try to get config from the base model if available
-    if is_gguf_model(model_id):
-        tokenizer_path = extract_tokenizer_from_gguf_path(model_id)
-        if tokenizer_path:
-            config_url = f"https://huggingface.co/{tokenizer_path}/raw/main/config.json"
-        else:
-            # Skip max length detection for GGUF models without clear tokenizer path
-            return 0
-    else:
-        config_url = f"https://huggingface.co/{model_id}/raw/main/config.json"
-
-    try:
-        response = await http_client.get(config_url, follow_redirects=True, timeout=httpx.Timeout(10.0))
-        response.raise_for_status()
-        config = response.json()
-        keys_to_check = ['max_position_embeddings', 'n_positions', 'model_max_length']
+    url = _config_url_for(model_id)
+    if not url:
+        return 0  # GGUF without a resolvable base repo
+    config = await _fetch_config_json(url)
+    if not isinstance(config, dict):
+        return 0
+    keys_to_check = ['max_position_embeddings', 'n_positions', 'model_max_length']
+    for key in keys_to_check:
+        if isinstance(config.get(key), int):
+            return config[key]
+    # Multimodal configs nest the LM fields under text_config.
+    text = config.get("text_config")
+    if isinstance(text, dict):
         for key in keys_to_check:
-            if key in config and isinstance(config[key], int):
-                return config[key]
-        return 0
-    except Exception as e:
-        logging.error(f"An error occurred while getting max length for {model_id}: {e}")
-        return 0
+            if isinstance(text.get(key), int):
+                return text[key]
+    return 0
 
 async def estimate_weight_bytes(model_id: str) -> "int | None":
-    """Best-effort estimate of a model's on-disk weight size in bytes, for the TP-fallback
-    decision (how many GPUs a model's weights need). Returns None when it can't be determined.
+    """Best-effort estimate of a model's on-disk weight size in bytes (quantization-aware).
 
-    Reads the safetensors shard index (one small JSON GET, same pattern as get_model_max_len);
-    that metadata already reflects quantized sizes. GGUF / non-safetensors repos return None,
-    in which case the caller degrades to the configured tensor_parallel_size."""
+    Primary: sum the sizes of all *.safetensors files from HF model metadata
+    (HfApi().model_info(files_metadata=True)) — handles single-file AND sharded repos, and gated
+    repos via the token. Fallback: the shard index's total_size (sharded only). Returns None when
+    neither works (e.g. GGUF / non-safetensors), so the caller degrades to discovery / configured tp."""
     if is_gguf_model(model_id) or '/' not in model_id or model_id.startswith(('http://', 'https://')):
         return None
+    token = HF_TOKEN if HF_TOKEN and HF_TOKEN.strip() else None
+    try:
+        info = await run_in_executor(partial(HfApi().model_info, model_id,
+                                             files_metadata=True, token=token))
+        total = 0
+        for s in (getattr(info, "siblings", None) or []):
+            name = getattr(s, "rfilename", "") or ""
+            if name.endswith(".safetensors"):
+                size = getattr(s, "size", None)
+                if size:
+                    total += int(size)
+        if total > 0:
+            return total
+    except Exception as e:
+        logging.warning(f"model_info weight sizing failed for {model_id}: {e}; trying shard index.")
+    # Fallback: shard index total_size (present only for multi-shard models).
     index_url = f"https://huggingface.co/{model_id}/raw/main/model.safetensors.index.json"
     try:
         resp = await http_client.get(index_url, follow_redirects=True, timeout=httpx.Timeout(10.0))
@@ -795,6 +923,84 @@ async def estimate_weight_bytes(model_id: str) -> "int | None":
     except Exception as e:
         logging.warning(f"Could not estimate weight size for {model_id}: {e}")
     return None
+
+def _dtype_bytes(torch_dtype) -> int:
+    """Bytes per element for a model's KV-cache dtype, inferred from config.json's torch_dtype.
+    Defaults to 2 (float16/bfloat16). fp8/int8 KV -> 1; float32 -> 4."""
+    s = str(torch_dtype).lower()
+    if "float32" in s or "fp32" in s:
+        return 4
+    if "fp8" in s or "8bit" in s or "int8" in s or "float8" in s:
+        return 1
+    return 2
+
+def _sliding_window_spec(cfg_text: dict, num_layers: int) -> "tuple[int, int]":
+    """(sliding_window, num_sliding_layers) for a model, or (0, 0) for full attention.
+
+    Evidence order: explicit per-layer `layer_types` (most accurate) -> Gemma-style
+    `sliding_window` + `sliding_window_pattern` (every Nth layer is global/full) -> a bare
+    `sliding_window` (Mistral convention: all layers sliding)."""
+    window = cfg_text.get("sliding_window")
+    if not isinstance(window, int) or window <= 0:
+        return 0, 0
+    layer_types = cfg_text.get("layer_types")
+    if isinstance(layer_types, list) and layer_types:
+        n_sliding = sum(1 for t in layer_types if isinstance(t, str) and "sliding" in t.lower())
+        return window, n_sliding
+    pattern = cfg_text.get("sliding_window_pattern")
+    if isinstance(pattern, int) and pattern > 1:
+        n_global = num_layers // pattern          # every `pattern`-th layer is full/global
+        return window, max(0, num_layers - n_global)
+    return window, num_layers                      # bare sliding_window -> assume all layers sliding
+
+async def get_model_kv_spec(model_id: str, tokenizer_repo: "str | None" = None) -> "dict | None":
+    """Fetch the KV-cache-relevant architecture fields from a model's config.json.
+
+    Returns {num_layers, num_kv_heads, head_dim, dtype_bytes, sliding_window, num_sliding_layers}
+    or None when the config can't be fetched/parsed. Multimodal repos nest the LM fields under
+    'text_config'. Sliding-window layers need far less KV than full-attention ones."""
+    url = _config_url_for(model_id, tokenizer_repo)
+    if not url:
+        return None
+    cfg = await _fetch_config_json(url)
+    if not isinstance(cfg, dict):
+        return None
+    text = cfg.get("text_config") if isinstance(cfg.get("text_config"), dict) else cfg
+    num_layers = text.get("num_hidden_layers")
+    n_heads = text.get("num_attention_heads")
+    n_kv = text.get("num_key_value_heads", n_heads)  # GQA -> kv heads; MHA -> all heads
+    hidden = text.get("hidden_size")
+    head_dim = text.get("head_dim") or (hidden // n_heads if (hidden and n_heads) else None)
+    if not (num_layers and n_kv and head_dim):
+        logging.warning(f"Incomplete KV spec for {model_id}: layers={num_layers}, "
+                        f"kv_heads={n_kv}, head_dim={head_dim}; falling back to discovery.")
+        return None
+    window, n_sliding = _sliding_window_spec(text, int(num_layers))
+    return {"num_layers": int(num_layers), "num_kv_heads": int(n_kv),
+            "head_dim": int(head_dim), "dtype_bytes": _dtype_bytes(text.get("torch_dtype", "float16")),
+            "sliding_window": int(window), "num_sliding_layers": int(n_sliding)}
+
+
+async def estimate_model_need_mib(model_id: str, model_cfg: ModelConfig, effective_tp: int) -> "float | None":
+    """Budget-mode per-card VRAM need (MiB) for a model = (weights + KV)/tp * factor + fixed margin.
+
+    Returns None when weights or the KV spec can't be determined (e.g. GGUF) — the caller then
+    falls back to sole-occupant discovery to measure the real footprint instead of guessing."""
+    wbytes = await estimate_weight_bytes(model_id)
+    if not wbytes:
+        return None
+    spec = await get_model_kv_spec(model_id)
+    if not spec:
+        return None
+    kv_total = placement.kv_cache_mib(
+        max_model_len=model_cfg.max_model_len, max_num_seqs=model_cfg.max_num_seqs,
+        num_layers=spec["num_layers"], num_kv_heads=spec["num_kv_heads"],
+        head_dim=spec["head_dim"], dtype_bytes=spec["dtype_bytes"],
+        sliding_window=spec.get("sliding_window", 0), num_sliding_layers=spec.get("num_sliding_layers", 0))
+    weights_mib = wbytes / (1024.0 * 1024.0)
+    return placement.estimate_need_mib(weights_mib, kv_total, effective_tp,
+                                       BUDGET_OVERHEAD_FACTOR, BUDGET_OVERHEAD_MIB)
+
 
 # Flags the gateway computes from placement (util cap, TP degree, model path). A model's
 # extra_args must NOT override these — doing so would defeat the co-location budget or the
@@ -976,9 +1182,9 @@ async def start_model_container(model_id: str, container_name: str, model_cfg: M
     if model_cfg.dtype and model_cfg.dtype != "auto":
         command.extend(["--dtype", model_cfg.dtype])
 
-    # Preserved global flag (not part of the per-model schema; override via extra_args).
-    if int(VLLM_MAX_NUM_SEQS) > 0:
-        command.extend(["--max-num-seqs", VLLM_MAX_NUM_SEQS])
+    # Per-model concurrency cap. Must match the value used to estimate KV-cache need in budget mode.
+    if model_cfg.max_num_seqs and model_cfg.max_num_seqs > 0:
+        command.extend(["--max-num-seqs", str(model_cfg.max_num_seqs)])
 
     # Add gpt-oss specific optimizations for Ampere/Ada GPUs (RTX 3090, A100, etc)
     if is_gpt_oss_model(model_id):
@@ -1129,17 +1335,24 @@ async def gateway_status():
                        if guid in c.get("gpu_uuids", []) and c.get("status") == ContainerStatus.LOADING)
         residents = [c["container_name"] for c in containers.values()
                      if guid in c.get("gpu_uuids", []) and c.get("status") != ContainerStatus.STOPPING]
+        total_mib = v.get("total")
         gpus_status[guid] = {
             "pool": uuid_to_pool.get(guid),
-            "total_mib": v.get("total"),
+            "total_mib": total_mib,
             "used_mib": v.get("used"),
             "reserved_mib": reserved,
+            # Budget mode: the per-GPU cap on total gateway VRAM (None in whole_card).
+            "budget_mib": (GPU_BUDGET_FRACTION * total_mib) if (PLACEMENT_MODE == "budget" and total_mib) else None,
             "residents": residents,
         }
     model_ids = set(list(queue_counts.keys()) + [c["model_id"] for c in containers.values()])
     return {
         "total_gpu_vram_mib": TOTAL_GPU_VRAM,
+        "placement_mode": PLACEMENT_MODE,
+        "gpu_budget_fraction": GPU_BUDGET_FRACTION if PLACEMENT_MODE == "budget" else None,
         "pools": pools,
+        # Per-model need/measured/util are in active_containers (reserved_mib / vram_footprint /
+        # effective_util) and known_footprints_mib (signature-stamped measured footprints).
         "gpus": gpus_status,
         "known_footprints_mib": footprints,
         "active_containers": containers,
@@ -1188,6 +1401,7 @@ def _build_gpu_views(pool_gpus, gpus_snapshot):
     blocked = set()
     for guid in pool_gpus:
         g = gpus_snapshot.get(guid)
+        total = float(g["total"]) if g else 0.0
         on_gpu = [c for c in active_containers.values() if guid in c.gpu_uuids]
         ready = [c for c in on_gpu if c.status == ContainerStatus.READY]
         loading = [c for c in on_gpu if c.status == ContainerStatus.LOADING]
@@ -1195,20 +1409,29 @@ def _build_gpu_views(pool_gpus, gpus_snapshot):
         residents_by_gpu[guid] = ready  # eviction candidates are READY only
         candidates.append(placement.GpuView(
             uuid=guid,
-            total=float(g["total"]) if g else 0.0,
+            total=total,
             used_smi=float(g["used"]) if g else 0.0,
             reserved=sum(c.reserved_mib for c in loading),
             # READY + STOPPING footprints both still occupy the card.
             ready_footprint=sum(c.vram_footprint for c in (ready + stopping)),
+            # Budget mode caps total gateway VRAM per card; whole_card leaves it uncapped (inf).
+            budget=(GPU_BUDGET_FRACTION * total) if PLACEMENT_MODE == "budget" else math.inf,
         ))
         if any(not c.colocate for c in on_gpu):  # incl. STOPPING — its VRAM is still resident
             blocked.add(guid)
     return candidates, residents_by_gpu, blocked
 
 async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, effective_tp,
-                              effective_util, run_discovery, before_used, meas_gpu):
+                              effective_util, run_discovery, before_used, meas_gpu,
+                              signature=None):
     """Start the container for an already-inserted LOADING `entry`, then flip it READY (or drop it
-    on failure — the single cleanup site). Whole-card discovery refines the footprint after READY."""
+    on failure — the single cleanup site).
+
+    After READY the footprint is set to GROUND TRUTH: the model's actual per-process VRAM
+    (`measure_model_vram`). If attribution is unavailable (old driver / no compute-apps) the
+    sole-occupant `run_discovery` delta is used; failing that, the reserved estimate stands. The
+    result is persisted stamped with `signature` (when provided) so it's reused only in a matching
+    sizing context. `signature=None` (degraded mode) skips measurement + persistence."""
     try:
         try:
             runtime = await start_model_container(
@@ -1249,28 +1472,34 @@ async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, e
                 logging.error(f"Could not clean up orphaned container {entry.container_name}: {e}")
             return None
 
-        # Whole-card discovery: measure the per-GPU footprint on one chosen GPU and persist it.
-        if run_discovery and meas_gpu:
-            logging.info(f"Discovery: sampling GPU {meas_gpu} VRAM 3x over 45s...")
-            samples = []
-            for _ in range(3):
-                await asyncio.sleep(15)
-                samples.append((await get_gpu_vram()).get(meas_gpu, {}).get("used", 0.0))
-            measured = max(samples) - before_used
-            if measured > 256:
-                logging.info(f"Measured per-GPU footprint for {target_model_id} on {meas_gpu}: {measured} MiB")
+        # Footprint = ground truth. Skip entirely in degraded mode (signature is None).
+        if signature is not None:
+            # 1) Primary: actual per-process VRAM for THIS model's container (works packed or alone).
+            measured = await measure_model_vram(entry.container_name, gpu_uuids or entry.gpu_uuids)
+            source = "compute-apps"
+            # 2) Fallback: sole-occupant whole-GPU delta (only meaningful when run_discovery / alone).
+            if measured is None and run_discovery and meas_gpu:
+                logging.info(f"compute-apps attribution unavailable; sampling GPU {meas_gpu} VRAM 3x over 45s...")
+                samples = []
+                for _ in range(3):
+                    await asyncio.sleep(15)
+                    samples.append((await get_gpu_vram()).get(meas_gpu, {}).get("used", 0.0))
+                delta = max(samples) - before_used
+                measured = delta if delta > 256 else None
+                source = "gpu-delta"
+            # 3) Last resort: keep the reserved estimate (already seeded into vram_footprint).
+            if measured is not None and measured > 256:
                 entry.vram_footprint = measured
-                known_footprints[target_model_id] = {
-                    "per_gpu_mib": float(measured), "effective_tp": effective_tp, "measured_at": time.time()}
+                footprint_mib = measured
             else:
-                # G5: unmeasurable -> persist the util*card ESTIMATE (the reservation we used), never a
-                # 0 sentinel. The model is "seen" with a sane footprint and won't re-run discovery.
-                logging.warning(f"Could not measure footprint for {target_model_id} ({measured} MiB); "
-                                f"persisting estimate {int(entry.reserved_mib)} MiB.")
-                entry.vram_footprint = entry.reserved_mib
-                known_footprints[target_model_id] = {
-                    "per_gpu_mib": float(entry.reserved_mib), "effective_tp": effective_tp, "measured_at": time.time()}
+                footprint_mib = entry.reserved_mib
+                source = (source or "") + "/estimate-fallback"
+            known_footprints[target_model_id] = {
+                "per_gpu_mib": float(footprint_mib), "effective_tp": effective_tp,
+                "effective_util": float(effective_util or 0.0), "measured_at": time.time(),
+                "signature": signature}
             await save_known_footprints_async()
+            logging.info(f"Footprint for {target_model_id}: {int(footprint_mib)} MiB (via {source}).")
         return entry
     finally:
         loading_tasks.pop(entry.container_name, None)  # release owner-liveness handle on every exit
@@ -1288,13 +1517,19 @@ async def _ensure_started(target_model_id, model_cfg):
     if ready is not None:
         return ready
 
-    record = known_footprints.get(target_model_id)          # None | {per_gpu_mib, effective_tp, measured_at}
-    is_discovery = record is None
+    # record shape: {per_gpu_mib, effective_tp, effective_util, measured_at, signature}. prior_tp is a
+    # deterministic optimization (reused regardless of signature). learned_mib / is_discovery are
+    # gated on a signature match below (once effective_tp is known) so stale / cross-context footprints
+    # are NOT reused.
+    record = known_footprints.get(target_model_id)
     prior_tp = record.get("effective_tp") if record else None
-    learned_mib = float(record.get("per_gpu_mib", 0.0)) if record else 0.0
+    raw_learned_mib = float(record.get("per_gpu_mib", 0.0)) if record else 0.0
     pool = pool_for(model_cfg)
     pool_gpus = MANAGED_POOLS.get(pool, [])
-    is_colocate = model_cfg.colocate
+    budget_mode = (PLACEMENT_MODE == "budget")
+    # Co-location is a whole_card-mode concept; in budget mode every model packs by VRAM accounting,
+    # so the colocate flag is moot and ignored.
+    is_colocate = model_cfg.colocate and not budget_mode
     util = model_cfg.gpu_memory_utilization
 
     # Degraded mode: VRAM accounting unavailable. One container at a time, but still record a
@@ -1345,8 +1580,35 @@ async def _ensure_started(target_model_id, model_cfg):
         effective_tp = placement.compute_effective_tp(wbytes, model_cfg.tensor_parallel_size,
                                                       prior_tp, pool_totals, util)
 
-    # Per-card need (F9): learned per-GPU footprint when known(>0), else util * that card's total.
-    need_fn = (lambda g: learned_mib) if learned_mib > 0 else (lambda g: util * g.total)
+    # Reuse a persisted footprint only when its signature matches the current sizing context;
+    # otherwise treat the model as unseen and re-measure (fixes cross-mode / config-change staleness).
+    current_sig = placement.footprint_signature(
+        PLACEMENT_MODE, model_cfg.max_model_len, model_cfg.max_num_seqs, effective_tp, util_basis=util)
+    seen = record is not None and placement.signature_matches(record, current_sig)
+    is_discovery = not seen
+    learned_mib = raw_learned_mib if seen else 0.0
+
+    # Per-card need.
+    #  - budget mode: weights + bounded KV + overhead, recomputed fresh from config each cold start
+    #    (so a max_model_len/max_num_seqs change takes effect). A model whose need can't be estimated
+    #    (GGUF / unknown arch) reuses a previously measured footprint, else falls back to discovery.
+    #  - whole_card mode (F9): learned per-GPU footprint when known(>0), else util * that card's total.
+    budget_need = None
+    budget_discovery = False
+    if budget_mode:
+        budget_need = await estimate_model_need_mib(target_model_id, model_cfg, effective_tp)
+        if budget_need is None:                 # GGUF / unknown arch -> can't estimate
+            if learned_mib > 0:
+                budget_need = learned_mib       # reuse a previously measured footprint
+            else:
+                budget_discovery = True         # measure as sole occupant on first load
+
+    if budget_mode and budget_need is not None:
+        need_fn = (lambda g, n=budget_need: n)              # constant per-card need
+    elif learned_mib > 0:
+        need_fn = (lambda g: learned_mib)
+    else:
+        need_fn = (lambda g: util * g.total)                # whole-card / discovery fallback
     colocate_wbytes = await estimate_weight_bytes(target_model_id) if is_colocate else None
 
     # DECIDE + reserve + insert LOADING — under state_lock (no I/O inside).
@@ -1381,6 +1643,13 @@ async def _ensure_started(target_model_id, model_cfg):
                         detail=(f"Cannot co-locate {target_model_id} on {chosen_uuids[0]}: budget "
                                 f"~{int(effective_util * total)} MiB < weights ~{int(need_mib)} MiB."))
             reserve_amt = effective_util * total
+        elif budget_mode and budget_need is not None:
+            # Size the launch util so vLLM takes ONLY this need; the budget cap makes it physically
+            # unable to exceed it, so an under-estimate fails only this model's startup, not a peer.
+            total = chosen_gv.total or max_total
+            effective_util = min(GPU_BUDGET_FRACTION,
+                                 (budget_need / total) if total > 0 else GPU_BUDGET_FRACTION)
+            reserve_amt = budget_need
         else:
             effective_util = None
             reserve_amt = need_fn(chosen_gv)
@@ -1395,14 +1664,22 @@ async def _ensure_started(target_model_id, model_cfg):
             created_at=time.time())
         active_containers[entry.container_name] = entry
         loading_tasks[entry.container_name] = asyncio.current_task()  # owner-liveness handle (G2)
-        logging.info(f"Placing {target_model_id} on GPU(s) {chosen_uuids} (pool '{pool}', "
-                     f"{'colocate util=%.3f' % effective_util if is_colocate else 'tp=%d' % effective_tp}, "
+        if is_colocate:
+            placed_desc = 'colocate util=%.3f' % effective_util
+        elif budget_mode and effective_util is not None:
+            placed_desc = 'budget util=%.3f tp=%d' % (effective_util, effective_tp)
+        else:
+            placed_desc = 'tp=%d' % effective_tp
+        logging.info(f"Placing {target_model_id} on GPU(s) {chosen_uuids} (pool '{pool}', {placed_desc}, "
                      f"~{int(reserve_amt)} MiB/GPU); evicting {evictions or 'nothing'}; slot {entry.container_name}.")
 
     # Evict + start OUTSIDE the lock.
     for name in evictions:
         await stop_container(name)
-    run_discovery = is_discovery and not is_colocate
+    # Per-process attribution (in _start_and_finalize) is the primary footprint source. `run_discovery`
+    # marks a sole-occupant load (unseen whole_card model, or a budget model whose need couldn't be
+    # estimated) — for those the whole-GPU delta is a valid FALLBACK if attribution is unavailable.
+    run_discovery = budget_discovery if budget_mode else (is_discovery and not is_colocate)
     # G4: take the discovery baseline AFTER evictions have actually released VRAM (stop_container
     # returns before the driver frees it), not from the pre-decision snapshot. Settle by polling the
     # chosen GPU's used until it stops dropping (or a short ceiling).
@@ -1413,7 +1690,7 @@ async def _ensure_started(target_model_id, model_cfg):
     return await _start_and_finalize(
         entry, target_model_id, model_cfg, gpu_uuids=chosen_uuids, effective_tp=effective_tp,
         effective_util=effective_util, run_discovery=run_discovery,
-        before_used=before_used, meas_gpu=chosen_uuids[0])
+        before_used=before_used, meas_gpu=chosen_uuids[0], signature=current_sig)
 
 # Catch-all proxy route (must be last)
 @app.api_route("/{path:path}", methods=["GET", "POST", "PUT", "DELETE"])

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -16,6 +16,7 @@ ALLOWED_CONFIG_KEYS = {
     "gpu_memory_utilization",
     "max_model_len",
     "tensor_parallel_size",
+    "max_num_seqs",  # max concurrent sequences (vLLM --max-num-seqs); bounds KV-cache need in budget mode
     "quantization",
     "dtype",
     "inactivity_timeout",
@@ -39,6 +40,7 @@ class ModelConfig:
     gpu_memory_utilization: float
     max_model_len: int
     tensor_parallel_size: int
+    max_num_seqs: int
     quantization: Optional[str]
     dtype: str
     inactivity_timeout: int
@@ -72,6 +74,10 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
     tensor_parallel_size = _require_int("tensor_parallel_size", name, merged["tensor_parallel_size"])
     if tensor_parallel_size < 1:
         raise ValueError(f"model '{name}': 'tensor_parallel_size' must be >= 1, got {tensor_parallel_size}")
+
+    max_num_seqs = _require_int("max_num_seqs", name, merged["max_num_seqs"])
+    if max_num_seqs < 1:
+        raise ValueError(f"model '{name}': 'max_num_seqs' must be >= 1, got {max_num_seqs}")
 
     inactivity_timeout = _require_int("inactivity_timeout", name, merged["inactivity_timeout"])
     if inactivity_timeout < 0:
@@ -107,6 +113,7 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
         gpu_memory_utilization=gmu,
         max_model_len=int(max_model_len),
         tensor_parallel_size=int(tensor_parallel_size),
+        max_num_seqs=int(max_num_seqs),
         quantization=quantization,
         dtype=dtype,
         inactivity_timeout=int(inactivity_timeout),
@@ -258,26 +265,81 @@ def validate_tp_against_pools(configs: "dict[str, ModelConfig]", pools: "dict[st
                 )
 
 
+def validate_budget_mode(configs: "dict[str, ModelConfig]", mode: str) -> None:
+    """In budget placement mode, every model needs a bounded context (max_model_len > 0).
+
+    vLLM fills its KV cache to whatever room it is given, so a model's VRAM need is only finite
+    once max_model_len (and max_num_seqs) bound the KV cache. Without that bound the gateway can't
+    size the model and pack the card, so we fail fast with an actionable message instead of silently
+    over-reserving. No-op in whole_card mode.
+    """
+    if mode != "budget":
+        return
+    bad = sorted(name for name, cfg in configs.items() if cfg.max_model_len <= 0)
+    if bad:
+        raise ValueError(
+            "PLACEMENT_MODE=budget requires max_model_len > 0 for every model (KV-cache need is "
+            f"otherwise unbounded). Models missing it: {bad}. Set 'max_model_len' per model or in the "
+            "'defaults' block, or set PLACEMENT_MODE=whole_card."
+        )
+
+
+# Memory-affecting vLLM flags that, in budget mode, must come from the structured config keys
+# (max_model_len / max_num_seqs) rather than extra_args — otherwise the launched config would diverge
+# from the size the gateway computes. --gpu-memory-utilization is already gateway-managed.
+BUDGET_FORBIDDEN_EXTRA_FLAGS = {
+    "--max-model-len", "--max-num-seqs", "--kv-cache-dtype", "--gpu-memory-utilization",
+}
+
+
+def validate_extra_args_budget(configs: "dict[str, ModelConfig]", mode: str) -> None:
+    """In budget mode, reject memory-affecting flags in extra_args (fail fast, actionable message).
+
+    Such flags would change the model's real VRAM use without changing the gateway's sizing, so the
+    first-load launch util could be wrong. No-op in whole_card mode.
+    """
+    if mode != "budget":
+        return
+    offenders = {}
+    for name, cfg in configs.items():
+        bad = [a for a in cfg.extra_args if str(a).split("=", 1)[0] in BUDGET_FORBIDDEN_EXTRA_FLAGS]
+        if bad:
+            offenders[name] = bad
+    if offenders:
+        raise ValueError(
+            "PLACEMENT_MODE=budget: memory-affecting flags must be set via the structured config keys "
+            f"(max_model_len / max_num_seqs), not extra_args. Offending models: {offenders}. They would "
+            "diverge from the gateway's sizing — move them to the model config or use PLACEMENT_MODE=whole_card."
+        )
+
+
 def migrate_footprints(raw: dict) -> dict:
     """Normalize the footprints file to the per-model record shape.
 
-    New shape: {repo: {"per_gpu_mib": float, "effective_tp": int, "measured_at": float}}.
-    Legacy shape was {repo: number} (a per-GPU footprint measured at tp=1; 0 = unmeasurable
-    sentinel). Migrate legacy scalar values forward (assume tp=1). Records already in the new
-    shape pass through. Unparseable entries are dropped.
+    New shape: {repo: {"per_gpu_mib": float, "effective_tp": int, "effective_util": float,
+    "measured_at": float}}. Legacy shape was {repo: number} (a per-GPU footprint measured at tp=1;
+    0 = unmeasurable sentinel). Migrate legacy scalar values forward (assume tp=1). Records already
+    in the new shape pass through (effective_util defaults to 0.0 for pre-budget-mode records).
+    Unparseable entries are dropped.
     """
     out = {}
     if not isinstance(raw, dict):
         return out
     for repo, val in raw.items():
         if isinstance(val, dict) and "per_gpu_mib" in val:
+            sig = val.get("signature")
             out[repo] = {
                 "per_gpu_mib": float(val.get("per_gpu_mib", 0.0)),
                 "effective_tp": int(val.get("effective_tp", 1) or 1),
+                "effective_util": float(val.get("effective_util", 0.0)),
                 "measured_at": float(val.get("measured_at", 0.0)),
+                # Carry the sizing signature forward; legacy records (no signature) get {} and are
+                # therefore never reused (treated as unseen -> re-measured). See placement.signature_matches.
+                "signature": sig if isinstance(sig, dict) else {},
             }
         elif isinstance(val, (int, float)) and not isinstance(val, bool):
-            out[repo] = {"per_gpu_mib": float(val), "effective_tp": 1, "measured_at": 0.0}
+            out[repo] = {"per_gpu_mib": float(val), "effective_tp": 1,
+                         "effective_util": 0.0, "measured_at": 0.0, "signature": {}}
         # anything else: drop (corrupt entry)
     return out
 

--- a/gateway/placement.py
+++ b/gateway/placement.py
@@ -24,10 +24,20 @@ class GpuView:
     used_smi: float = 0.0
     reserved: float = 0.0
     ready_footprint: float = 0.0
+    # Per-GPU cap on the TOTAL VRAM this gateway may fill across ALL its models on this card
+    # (budget placement mode). math.inf = uncapped, i.e. the legacy whole-card behavior is unchanged.
+    budget: float = math.inf
 
     @property
     def free(self) -> float:
-        return self.total - max(self.used_smi, self.ready_footprint) - self.reserved
+        physical_free = self.total - max(self.used_smi, self.ready_footprint) - self.reserved
+        if math.isinf(self.budget):
+            return physical_free
+        # In budget mode also cap by the gateway's own remaining budget. External (non-gateway)
+        # VRAM is still respected through used_smi in physical_free; the budget caps only OUR models.
+        gateway_used = self.ready_footprint + self.reserved
+        budget_free = self.budget - gateway_used
+        return min(physical_free, budget_free)
 
 
 def _evictable_lru(residents, now, min_resident_seconds, allow_fresh):
@@ -145,6 +155,95 @@ def minimal_tp_to_fit(weight_bytes, card_total_mib, util, overhead=1.2, pool_siz
     if pool_size is not None:
         tp = min(tp, pool_size)
     return tp
+
+
+def kv_cache_mib(max_model_len, max_num_seqs, num_layers, num_kv_heads, head_dim, dtype_bytes,
+                 sliding_window=0, num_sliding_layers=0) -> float:
+    """Estimated TOTAL KV-cache size (MiB) for a model held resident at the given context/concurrency.
+
+    Per (full-attention) layer a sequence needs `max_model_len` tokens of KV; a sliding-window layer
+    only needs `min(sliding_window, max_model_len)` (Gemma 3, Mistral interleave these). So:
+        token-layers/seq = full_layers * L + sliding_layers * min(window, L)        (L = max_model_len)
+        KV bytes = 2 (key+value) * num_kv_heads * head_dim * dtype_bytes * token-layers/seq * seqs
+    With `sliding_window<=0` or `num_sliding_layers<=0` every layer is full (legacy behavior). This is
+    the whole-model KV; under tensor parallel the caller divides by tp. Returns 0.0 if any core input
+    is non-positive (unknown -> caller falls back to discovery).
+    """
+    vals = (max_model_len, max_num_seqs, num_layers, num_kv_heads, head_dim, dtype_bytes)
+    if any((v is None or v <= 0) for v in vals):
+        return 0.0
+    if sliding_window and sliding_window > 0 and num_sliding_layers and num_sliding_layers > 0:
+        sliding = min(int(num_sliding_layers), int(num_layers))
+        full = int(num_layers) - sliding
+        eff_sliding_len = min(int(sliding_window), int(max_model_len))
+    else:
+        full, sliding, eff_sliding_len = int(num_layers), 0, 0
+    token_layers_per_seq = full * int(max_model_len) + sliding * eff_sliding_len
+    total_bytes = 2 * int(num_kv_heads) * int(head_dim) * int(dtype_bytes) \
+        * token_layers_per_seq * int(max_num_seqs)
+    return float(total_bytes) / (1024.0 * 1024.0)
+
+
+# Canonical keys of a footprint "signature" — the inputs that determine a model's measured size.
+# A persisted footprint is reused only when its stored signature matches the current request's, so a
+# mode switch or a config change (context length / concurrency / TP / util basis) forces re-measure.
+_SIGNATURE_KEYS = ("mode", "max_model_len", "max_num_seqs", "effective_tp", "util_basis")
+
+
+def footprint_signature(mode, max_model_len, max_num_seqs, effective_tp, util_basis=0.0) -> dict:
+    """Build the signature stamped onto a footprint record (and compared on reuse)."""
+    return {
+        "mode": mode,
+        "max_model_len": int(max_model_len),
+        "max_num_seqs": int(max_num_seqs),
+        "effective_tp": int(effective_tp),
+        "util_basis": round(float(util_basis), 4),
+    }
+
+
+def signature_matches(record, sig) -> bool:
+    """True iff `record` carries a signature equal to `sig` across all canonical keys.
+
+    Legacy records (no signature, or `{}`) never match -> they are treated as unseen and re-measured,
+    which is the safe default after a schema/behavior change."""
+    stored = record.get("signature") if isinstance(record, dict) else None
+    if not isinstance(stored, dict) or not stored:
+        return False
+    return all(stored.get(k) == sig.get(k) for k in _SIGNATURE_KEYS)
+
+
+def attribute_vram(compute_app_rows, host_pids, gpu_uuids) -> float:
+    """Sum the GPU memory (MiB) of compute processes that belong to `host_pids` on `gpu_uuids`.
+
+    `compute_app_rows`: iterable of (gpu_uuid, pid, used_mib) from
+    `nvidia-smi --query-compute-apps`. Sums across all of a model's `gpu_uuids` (so a tensor-parallel
+    model's footprint is its total across cards). Returns 0.0 when nothing matches — the caller treats
+    that as "attribution unavailable" and falls back to delta measurement.
+    """
+    pids = {int(p) for p in host_pids}
+    uuids = set(gpu_uuids)
+    total = 0.0
+    for row in compute_app_rows:
+        try:
+            guid, pid, mib = row
+            if int(pid) in pids and guid in uuids:
+                total += float(mib)
+        except (TypeError, ValueError):
+            continue
+    return total
+
+
+def estimate_need_mib(weights_mib, kv_mib_total, tp, overhead_factor, fixed_overhead_mib) -> float:
+    """Per-card VRAM need (MiB) for a model in budget mode.
+
+    Weights and KV both shard across `tp` cards; the result is scaled by `overhead_factor`
+    (activations / fragmentation) and a per-card `fixed_overhead_mib` (CUDA context, cudagraphs)
+    that does NOT shard. Bias these generous: the launch util cap makes vLLM physically unable to
+    exceed this, so an under-estimate only fails THIS model's own startup, never a co-resident.
+    """
+    tp = max(1, int(tp or 1))
+    shardable = (max(0.0, weights_mib) + max(0.0, kv_mib_total)) / tp
+    return shardable * overhead_factor + fixed_overhead_mib
 
 
 def _gpu_fit_cost(g, residents, needed, now, min_resident_seconds):

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -14,7 +14,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 from config_loader import (  # noqa: E402
     resolve_model_configs, build_fallback_configs, resolve_pools,
     validate_model_pools, validate_tp_against_pools, validate_colocate,
-    validate_pools_visible, migrate_footprints,
+    validate_pools_visible, validate_budget_mode, validate_extra_args_budget, migrate_footprints,
 )
 
 # Mirrors app.builtin_model_defaults() with stock env-var defaults.
@@ -22,6 +22,7 @@ BUILTINS = {
     "gpu_memory_utilization": 0.90,
     "max_model_len": 0,
     "tensor_parallel_size": 1,
+    "max_num_seqs": 16,
     "quantization": None,
     "dtype": "auto",
     "inactivity_timeout": 1800,
@@ -283,12 +284,89 @@ def test_migrate_footprints():
         "org/c": 0,                                                  # legacy sentinel
         "org/bad": "nonsense",                                       # corrupt -> dropped
     })
-    assert out["org/a"] == {"per_gpu_mib": 20000.0, "effective_tp": 1, "measured_at": 0.0}
+    assert out["org/a"] == {"per_gpu_mib": 20000.0, "effective_tp": 1,
+                            "effective_util": 0.0, "measured_at": 0.0, "signature": {}}
     assert out["org/b"]["effective_tp"] == 2 and out["org/b"]["per_gpu_mib"] == 13000.0
-    assert out["org/c"] == {"per_gpu_mib": 0.0, "effective_tp": 1, "measured_at": 0.0}
+    assert out["org/b"]["effective_util"] == 0.0  # absent in old new-shape record -> defaulted
+    assert out["org/b"]["signature"] == {}        # legacy record -> empty signature (never reused)
+    assert out["org/c"] == {"per_gpu_mib": 0.0, "effective_tp": 1,
+                            "effective_util": 0.0, "measured_at": 0.0, "signature": {}}
     assert "org/bad" not in out
     assert migrate_footprints({}) == {} and migrate_footprints(None) == {}
     print("ok: migrate_footprints")
+
+
+def test_max_num_seqs_precedence_and_validation():
+    raw = {
+        "defaults": {"max_num_seqs": 32},
+        "models": {
+            "a": {"repo": "org/a", "max_num_seqs": 4},   # per-model wins
+            "b": {"repo": "org/b"},                        # inherits defaults
+            "c": {"repo": "org/c"},
+        },
+    }
+    cfgs = resolve_model_configs(raw, BUILTINS)
+    assert cfgs["a"].max_num_seqs == 4
+    assert cfgs["b"].max_num_seqs == 32
+    # builtin fallback when neither sets it
+    cfgs2 = resolve_model_configs({"models": {"m": {"repo": "o/r"}}}, BUILTINS)
+    assert cfgs2["m"].max_num_seqs == BUILTINS["max_num_seqs"]
+    # type/range validation
+    _expect_error({"models": {"m": {"repo": "o/r", "max_num_seqs": 0}}}, "max_num_seqs")
+    _expect_error({"models": {"m": {"repo": "o/r", "max_num_seqs": True}}}, "max_num_seqs")
+    print("ok: max_num_seqs precedence + validation")
+
+
+def test_validate_budget_mode():
+    bounded = resolve_model_configs(
+        {"defaults": {"max_model_len": 8192}, "models": {"m": {"repo": "o/r"}}}, BUILTINS)
+    unbounded = resolve_model_configs({"models": {"m": {"repo": "o/r"}}}, BUILTINS)  # max_model_len 0
+    # budget mode: bounded passes, unbounded fails fast naming the offending model.
+    validate_budget_mode(bounded, "budget")          # no raise
+    try:
+        validate_budget_mode(unbounded, "budget")
+    except ValueError as e:
+        assert "max_model_len" in str(e) and "'m'" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for unbounded model in budget mode")
+    # whole_card mode: no requirement, both pass.
+    validate_budget_mode(unbounded, "whole_card")
+    print("ok: validate_budget_mode")
+
+
+def test_validate_extra_args_budget():
+    raw = {
+        "defaults": {"max_model_len": 8192},
+        "models": {
+            "ok": {"repo": "o/ok", "extra_args": ["--enable-prefix-caching"]},
+            "bad": {"repo": "o/bad", "extra_args": ["--max-model-len", "65536"]},
+        },
+    }
+    cfgs = resolve_model_configs(raw, BUILTINS)
+    # budget mode: a memory-affecting flag in extra_args is rejected, naming the model.
+    try:
+        validate_extra_args_budget(cfgs, "budget")
+    except ValueError as e:
+        assert "bad" in str(e) and "extra_args" in str(e), e
+    else:
+        raise AssertionError("expected ValueError for --max-model-len in extra_args (budget)")
+    # The '=' form is caught too.
+    cfgs2 = resolve_model_configs(
+        {"defaults": {"max_model_len": 8192},
+         "models": {"m": {"repo": "o/m", "extra_args": ["--kv-cache-dtype=fp8"]}}}, BUILTINS)
+    try:
+        validate_extra_args_budget(cfgs2, "budget")
+        raise AssertionError("expected ValueError for --kv-cache-dtype= in extra_args")
+    except ValueError:
+        pass
+    # whole_card mode: no restriction.
+    validate_extra_args_budget(cfgs, "whole_card")
+    # A model with only harmless extra_args passes in budget mode.
+    cfgs3 = resolve_model_configs(
+        {"defaults": {"max_model_len": 8192},
+         "models": {"m": {"repo": "o/m", "extra_args": ["--enable-prefix-caching"]}}}, BUILTINS)
+    validate_extra_args_budget(cfgs3, "budget")
+    print("ok: validate_extra_args_budget")
 
 
 if __name__ == "__main__":

--- a/tests/test_placement.py
+++ b/tests/test_placement.py
@@ -12,8 +12,10 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
 from placement import (  # noqa: E402
     select_evictions, select_gpu, GpuView, select_placement, minimal_tp_to_fit, _homogeneous,
-    select_colocated, compute_effective_tp,
+    select_colocated, compute_effective_tp, kv_cache_mib, estimate_need_mib,
+    attribute_vram, footprint_signature, signature_matches,
 )
+import math  # noqa: E402
 
 
 @dataclass
@@ -304,6 +306,120 @@ def test_select_colocated_blocked_gpus():
     # If both are blocked -> None.
     uuid2, _ = select_colocated([a, b], rbg, lambda g: 8000, {"A", "B"}, NOW, 90)
     assert uuid2 is None
+
+
+# --- Phase 4: budget placement (kv_cache_mib, estimate_need_mib, GpuView.budget) ---
+
+def test_kv_cache_mib_known_value():
+    # Llama-3-8B-ish: 32 layers, 8 kv heads, head_dim 128, bf16(2B), 8192 ctx x 16 seqs.
+    # bytes/token = 2 * 32 * 8 * 128 * 2 = 131072; * 8192 * 16 = 17_179_869_184 B = 16384 MiB.
+    assert kv_cache_mib(8192, 16, 32, 8, 128, 2) == 16384.0
+    # Halving concurrency halves the KV.
+    assert kv_cache_mib(8192, 8, 32, 8, 128, 2) == 8192.0
+    # Any non-positive/None input -> 0.0 (unknown -> caller falls back to discovery).
+    assert kv_cache_mib(0, 16, 32, 8, 128, 2) == 0.0
+    assert kv_cache_mib(8192, 16, 32, 8, None, 2) == 0.0
+
+
+def test_estimate_need_mib_overhead_and_tp():
+    approx = lambda a, b: abs(a - b) < 1e-6  # noqa: E731
+    # (16000 + 5000) * 1.1 + 1024 = 24124 at tp=1.
+    assert approx(estimate_need_mib(16000, 5000, 1, 1.1, 1024), 24124.0)
+    # tp=2 shards weights+KV across 2 cards but the fixed margin is per-card:
+    # (21000/2) * 1.1 + 1024 = 11550 + 1024 = 12574.
+    assert approx(estimate_need_mib(16000, 5000, 2, 1.1, 1024), 12574.0)
+    # No KV known (0) -> weights-only + overhead.
+    assert approx(estimate_need_mib(10000, 0, 1, 1.0, 0), 10000.0)
+
+
+def test_gpuview_budget_caps_free():
+    # 24 GB card, nothing used. budget cap 0.5*24000 = 12000 is tighter than physical (24000).
+    g = GpuView("A", total=24000, used_smi=0, ready_footprint=0, budget=12000)
+    assert g.free == 12000
+    # With a gateway model already holding 8000, budget_free = 12000-8000 = 4000 (still tighter).
+    g2 = GpuView("A", total=24000, used_smi=8000, ready_footprint=8000, budget=12000)
+    assert g2.free == 4000
+    # External (non-gateway) VRAM makes physical tighter than budget: used_smi 22000, no gateway
+    # models -> physical 2000 < budget_free 12000.
+    g3 = GpuView("A", total=24000, used_smi=22000, ready_footprint=0, budget=12000)
+    assert g3.free == 2000
+    # Default budget is inf -> identical to legacy physical-only free.
+    g4 = GpuView("A", total=24000, used_smi=5000, ready_footprint=5000)
+    assert math.isinf(g4.budget) and g4.free == 19000
+
+
+def test_budget_packs_two_models_no_eviction():
+    # budget 0.9*24000 = 21600. Two ~10000-MiB models both fit (sum 20000 <= 21600) with no evict.
+    budget = 0.9 * 24000
+    g = GpuView("A", total=24000, used_smi=0, ready_footprint=0, budget=budget)
+    chosen, ev = select_gpu([g], {"A": []}, lambda gg: 10000, NOW, 90)
+    assert chosen == "A" and ev == []
+    # Second model arrives with the first resident (10000 used).
+    g2 = GpuView("A", total=24000, used_smi=10000, ready_footprint=10000, budget=budget)
+    res = [R("first", 10000, OLD, loaded_at=OLD)]
+    chosen2, ev2 = select_gpu([g2], {"A": res}, lambda gg: 10000, NOW, 90)
+    assert chosen2 == "A" and ev2 == []   # 10000 + 10000 = 20000 <= 21600, no eviction
+
+
+def test_budget_full_triggers_eviction():
+    # budget 21600 already holds two idle 10000 models (20000); a 10000 model needs room -> evict LRU.
+    budget = 0.9 * 24000
+    g = GpuView("A", total=24000, used_smi=20000, ready_footprint=20000, budget=budget)
+    res = [R("old", 10000, NOW - 900, loaded_at=OLD),
+           R("new", 10000, NOW - 5, loaded_at=OLD)]
+    chosen, ev = select_gpu([g], {"A": res}, lambda gg: 10000, NOW, 90)
+    assert chosen == "A" and ev == ["old"], (chosen, ev)   # free one slot, keep the newer model
+
+
+def test_budget_smaller_than_need_returns_none():
+    # A single model needs 15000 but the budget only allows 12000 and nothing is evictable.
+    g = GpuView("A", total=24000, used_smi=0, ready_footprint=0, budget=12000)
+    chosen, ev = select_gpu([g], {"A": []}, lambda gg: 15000, NOW, 90)
+    assert chosen is None, (chosen, ev)
+
+
+# --- Phase 5: sliding-window KV, per-process attribution, footprint signatures ---
+
+def test_kv_cache_mib_sliding_window():
+    # Gemma-3-like: 34 layers, 28 sliding (window 1024), 6 full; full attention vastly larger.
+    full = kv_cache_mib(32768, 8, 34, 8, 256, 2)
+    slide = kv_cache_mib(32768, 8, 34, 8, 256, 2, sliding_window=1024, num_sliding_layers=28)
+    assert slide < full / 3, (slide, full)            # sliding is far cheaper
+    # Window >= context collapses to full for those layers (no benefit).
+    eq = kv_cache_mib(512, 8, 34, 8, 256, 2, sliding_window=4096, num_sliding_layers=28)
+    assert eq == kv_cache_mib(512, 8, 34, 8, 256, 2)  # min(window, L) = L
+    # No sliding info -> identical to legacy all-full.
+    assert kv_cache_mib(8192, 16, 32, 8, 128, 2, sliding_window=0, num_sliding_layers=0) \
+        == kv_cache_mib(8192, 16, 32, 8, 128, 2)
+    # Hand value: 1 full layer, L=1000, 1 seq, 1 kv-head, head_dim 1, 2 bytes -> 2*1*1*2*1000/2^20.
+    assert abs(kv_cache_mib(1000, 1, 1, 1, 1, 2) - (2 * 1000 * 2) / (1024.0 * 1024.0)) < 1e-9
+
+
+def test_attribute_vram():
+    rows = [("GPU-a", 111, 8000.0), ("GPU-a", 222, 1200.0),
+            ("GPU-b", 333, 5000.0), ("GPU-a", 999, 4000.0)]  # 999 is a foreign process
+    # Only our pids on GPU-a.
+    assert attribute_vram(rows, {111, 222}, ["GPU-a"]) == 9200.0
+    # Tensor-parallel: sum our pid across both cards.
+    assert attribute_vram([("GPU-a", 1, 6000.0), ("GPU-b", 1, 6000.0)], {1}, ["GPU-a", "GPU-b"]) == 12000.0
+    # No match -> 0.0 (caller falls back to delta measurement).
+    assert attribute_vram(rows, {555}, ["GPU-a"]) == 0.0
+    assert attribute_vram([], {111}, ["GPU-a"]) == 0.0
+    # Malformed rows are skipped, not fatal.
+    assert attribute_vram([("GPU-a", "x", 1.0), ("GPU-a", 111, 50.0)], {111}, ["GPU-a"]) == 50.0
+
+
+def test_footprint_signature_and_match():
+    sig = footprint_signature("budget", 32768, 8, 1, util_basis=0.9)
+    assert signature_matches({"signature": sig}, sig)
+    # Any differing sizing input -> mismatch (forces re-measure).
+    assert not signature_matches({"signature": sig}, footprint_signature("whole_card", 32768, 8, 1, 0.9))
+    assert not signature_matches({"signature": sig}, footprint_signature("budget", 16384, 8, 1, 0.9))
+    assert not signature_matches({"signature": sig}, footprint_signature("budget", 32768, 16, 1, 0.9))
+    assert not signature_matches({"signature": sig}, footprint_signature("budget", 32768, 8, 2, 0.9))
+    # Legacy / missing signature never matches.
+    assert not signature_matches({"signature": {}}, sig)
+    assert not signature_matches({}, sig)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

Today every model is sized to a whole card, so a 9B and a small Gemma can't co-reside on one 24 GB GPU — the gateway LRU-evicts one to load the other (a ~5-min cold start each swap) even though both fit together.

This adds **`PLACEMENT_MODE=budget`** (the new default): `gpu_memory_utilization` becomes a **per-GPU total cap**, and each model is sized to *only what it needs* (weights + bounded KV + overhead) so multiple models **pack onto one card**. `PLACEMENT_MODE=whole_card` preserves the legacy one-model-per-card LRU-swap behavior (and `colocate`).

## How it works

- **Launch util = `need / card_total`.** Because `--gpu-memory-utilization` is a hard fraction of total card memory, a model is *physically unable* to exceed its budgeted share — so an under-estimate can only fail **its own** startup, never OOM a co-resident.
- **Sizing bootstrap (accurate):** weights from `HfApi().model_info` (single-file + sharded + gated repos); KV estimate is **sliding-window-aware** (Gemma 3 / Mistral), avoiding ~5× over-sizing.
- **Ground-truth accounting:** after a model is READY, its footprint is its **actual per-process VRAM** (`nvidia-smi` compute-apps attributed to the container's PIDs), falling back to whole-GPU delta, then the estimate.
- **Context-keyed footprints:** records are stamped with a signature (mode + `max_model_len` + `max_num_seqs` + tp + util) and reused only on match → a mode/config change **re-measures automatically** (no stale sizing, no cross-mode OOM).

## Safety / fail-fast
- Budget mode requires `max_model_len > 0` and rejects memory-affecting flags in `extra_args`.
- `VLLM_MAX_NUM_SEQS=0` (old "omit the flag") is coerced to 16.
- Un-estimable models (GGUF / no readable config) load sole-occupant once, are measured, then pack.
- `/gateway/status` now exposes `placement_mode`, per-GPU `budget_mib`, and measured footprints.

## Tests
Pure helpers in `placement.py` / `config_loader.py` are unit-tested docker-free: **38 placement + 18 config** tests pass (`python tests/test_placement.py`, `python tests/test_config_resolution.py`).

## Notes for review
- The design rationale and a re-verified review (with the OOM-risk corrections) are in `docs/review-budget-mode-findings.md`.
- ⚠️ Behavior change: with `budget` as the default, a legacy `ALLOWED_MODELS_JSON` deployment (no per-model `max_model_len`) will refuse to start until you set `max_model_len` or `PLACEMENT_MODE=whole_card`.
- The per-process measurement path (compute-apps + `docker top` + timing) is validated by construction; it needs the GPU box to exercise end-to-end (see verification section in the findings doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)