### PR TITLE
Budget mode follow-ups: gated-config auth + compose queue tunables

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,12 @@ services:
       BUDGET_OVERHEAD_FACTOR: ${BUDGET_OVERHEAD_FACTOR:-1.1}
       BUDGET_OVERHEAD_MIB: ${BUDGET_OVERHEAD_MIB:-1024}
 
+      # --- QUEUEING (per model) ---
+      # Max concurrent requests forwarded to each model's vLLM, and max requests queued before
+      # the gateway returns 429. (KV-cache capacity still bounds true concurrency — see README.)
+      GATEWAY_MAX_CONCURRENT: ${GATEWAY_MAX_CONCURRENT:-50}
+      GATEWAY_MAX_QUEUE_SIZE: ${GATEWAY_MAX_QUEUE_SIZE:-200}
+
       # --- GPU PINNING / POOLS ---
       # For multi-GPU, declare a 'pools:' section in models.yaml (one gateway manages
       # several GPUs and places each model on a GPU in its pool). For a single GPU, leave

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -831,13 +831,22 @@ async def stop_container(container_name: str, drain_timeout: float = 30.0):
         async with state_lock:
             active_containers.pop(container_name, None)
 
+def _hf_auth_headers() -> dict:
+    """Authorization header for huggingface.co requests when a token is configured.
+
+    Gated repos (e.g. google/gemma-*) return 401 on even raw config.json without auth, which would
+    make the KV-spec / max-len lookups silently fail and the model fall back to whole-card discovery.
+    The token is accepted (and ignored) on public repos, so it's always safe to send."""
+    tok = HF_TOKEN if HF_TOKEN and HF_TOKEN.strip() else None
+    return {"Authorization": f"Bearer {tok}"} if tok else {}
+
 async def hf_repo_exists(repo_id: str) -> bool:
     """Return True if repo_id has a readable config.json on HuggingFace."""
     if not repo_id:
         return False
     url = f"https://huggingface.co/{repo_id}/raw/main/config.json"
     try:
-        resp = await http_client.get(url, timeout=5)
+        resp = await http_client.get(url, timeout=5, headers=_hf_auth_headers())
         return resp.status_code == 200
     except Exception:
         return False
@@ -859,7 +868,8 @@ async def _fetch_config_json(config_url: str) -> "dict | None":
         return _config_json_cache[config_url]
     cfg = None
     try:
-        resp = await http_client.get(config_url, follow_redirects=True, timeout=httpx.Timeout(10.0))
+        resp = await http_client.get(config_url, follow_redirects=True, timeout=httpx.Timeout(10.0),
+                                     headers=_hf_auth_headers())
         resp.raise_for_status()
         parsed = resp.json()
         cfg = parsed if isinstance(parsed, dict) else None


### PR DESCRIPTION
Follow-ups that landed on the `budget-placement-mode` branch *after* #15 was merged, so they aren't in `master` yet.

### 1. Authenticate HF `config.json` fetches (gated models)
Gated repos (e.g. `google/gemma-3-4b-it`) return 401 on raw `config.json` without a token, which made `get_model_kv_spec` / `get_model_max_len` silently fail → the model fell back to whole-card discovery and never packed. Now the HF token is sent (`_hf_auth_headers`) on the `config.json` fetch and the repo-exists check. The token is accepted and ignored on public repos, so it's always safe. → gated Gemma now auto-sizes and packs like the others.

### 2. Wire `GATEWAY_MAX_CONCURRENT` / `GATEWAY_MAX_QUEUE_SIZE` into compose
These were settable via `.env` for `${VAR}` substitution but never referenced in the `environment:` block, so Compose never passed them into the container and the app used its in-app defaults. Added them (defaults 50 / 200) so a direct-from-GitHub deploy honors `.env`.

No logic changes beyond the above; 38 placement + 18 config tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)