### PR TITLE
Budget mode: kv_reservation_seqs knob + named profiles of one model

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,43 @@ models:
   gemma:   { repo: cyankiwi/gemma-4-E4B-it-AWQ-INT4, quantization: awq, max_model_len: 32768 }
 ```
 
+#### Concurrency vs. packing: `kv_reservation_seqs`
+
+`max_num_seqs` is vLLM's scheduler width *and*, by default, the amount of KV the gateway reserves
+(`max_model_len × max_num_seqs`). For a model that takes **many short requests**, reserving for the full
+worst-case concurrency wastes VRAM. Set **`kv_reservation_seqs`** below `max_num_seqs` to reserve KV for
+fewer sequences while still admitting the full width — extra requests queue/page within the reserved
+pool instead of demanding proportional VRAM:
+
+```yaml
+judge-fast:
+  repo: cyankiwi/Qwen3.5-4B-AWQ-4bit
+  max_model_len: 8192
+  max_num_seqs: 32          # admit up to 32 concurrent
+  kv_reservation_seqs: 4    # but only reserve KV for 4 -> packs like a 4-way model
+```
+
+This works because the requests are short: 4 sequences' worth of KV blocks holds far more than 4 short
+requests. Caveats: it does **not** guarantee 32-way at long context (you still only fit ~4 long ones,
+the rest defer); the pool is static; and it's a tuning dial (over-reserve → packs poorly, under-reserve →
+queuing) — but never an OOM (the util cap holds). Leave it unset for the default (= `max_num_seqs`).
+
+#### Multiple profiles of one model
+
+Model identity is the **config name**, not the repo, so you can register one repo under several names
+with different launch profiles and have your application route to the right one — e.g. a
+short-context/high-concurrency profile for burst work and a long-context profile for big jobs (you can't
+change `max_model_len` per request, so this genuinely needs two launches):
+
+```yaml
+coder-short: { repo: Qwen/Qwen2.5-Coder-7B-Instruct, max_model_len: 8192,  max_num_seqs: 16, kv_reservation_seqs: 4 }
+coder-long:  { repo: Qwen/Qwen2.5-Coder-7B-Instruct, max_model_len: 32768, max_num_seqs: 1 }
+```
+
+Each name is an independent model (own container, footprint, queue). **Caveat:** if both are resident at
+once the weights occupy VRAM **twice**; otherwise the gateway swaps between them (a reload on switch). Best
+when used in batches rather than interleaved request-by-request.
+
 ### `whole_card`
 
 The legacy behavior: each model fills its card at its own `gpu_memory_utilization`, and the gateway

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -57,7 +57,10 @@ defaults:                      # optional; applied to every model unless overrid
   gpu_memory_utilization: 0.90 # whole_card mode: per-model card share. budget mode: unused for
                                # sizing (GPU_BUDGET_FRACTION is the cap); still the discovery util.
   max_model_len: 0             # 0 = native max (whole_card). budget mode REQUIRES > 0 per model.
-  max_num_seqs: 16             # max concurrent sequences (--max-num-seqs); bounds KV need in budget mode
+  max_num_seqs: 16             # vLLM scheduler width (--max-num-seqs)
+  # kv_reservation_seqs: null  # budget mode: # of sequences to RESERVE KV for. null -> = max_num_seqs.
+                               # Set BELOW max_num_seqs to allow high concurrency for SHORT requests
+                               # while packing tightly (excess sequences queue/page in the reserved pool).
   tensor_parallel_size: 1
   quantization: null           # awq | gptq | fp8 | null
   dtype: auto                  # auto | float16 | bfloat16 | ...
@@ -123,6 +126,32 @@ models:                        # required, non-empty
     pool: llm
     max_model_len: 32768
     max_num_seqs: 8
+
+  # --- High concurrency without hogging the budget (kv_reservation_seqs) ----
+  # Admit up to 32 concurrent requests (scheduler width) but only RESERVE KV for 4 — so this model
+  # packs like a 4-way model yet absorbs bursts of SHORT requests (the extra ones queue/page within
+  # the reserved pool). Ideal for LLM-as-judge / ranking / eval traffic (many short calls).
+  judge-fast:
+    repo: cyankiwi/Qwen3.5-4B-AWQ-4bit
+    pool: llm
+    max_model_len: 8192
+    max_num_seqs: 32
+    kv_reservation_seqs: 4
+
+  # --- Multiple named profiles of the SAME repo ----------------------------
+  # Identity is the config NAME, so you can register one repo twice with different launch profiles
+  # and have the application route to whichever fits the request (short-burst vs long-context).
+  # NOTE: if both are loaded at once the weights sit in VRAM TWICE; otherwise the gateway swaps
+  # between them. Best when you use them in batches rather than interleaved request-by-request.
+  coder-short:
+    repo: Qwen/Qwen2.5-Coder-7B-Instruct
+    max_model_len: 8192
+    max_num_seqs: 16
+    kv_reservation_seqs: 4
+  coder-long:
+    repo: Qwen/Qwen2.5-Coder-7B-Instruct   # same repo, long-context profile
+    max_model_len: 32768
+    max_num_seqs: 1
 
   # A large model forced across both 3090s with tensor parallel. tensor_parallel_size must
   # not exceed the GPUs declared in the pool (validated at startup), and the pool must be

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -683,6 +683,7 @@ def builtin_model_defaults() -> dict:
         # A non-positive VLLM_MAX_NUM_SEQS used to mean "omit the flag"; max_num_seqs is now a real
         # per-model setting (>= 1) and bounds KV need in budget mode, so coerce 0/invalid to 16.
         "max_num_seqs": (int(VLLM_MAX_NUM_SEQS) if int(VLLM_MAX_NUM_SEQS) >= 1 else 16),
+        "kv_reservation_seqs": None,  # None -> reserve KV for max_num_seqs (today's behavior)
         "quantization": None,
         "dtype": "auto",
         "inactivity_timeout": VLLM_INACTIVITY_TIMEOUT,
@@ -997,11 +998,21 @@ async def get_model_kv_spec(model_id: str, tokenizer_repo: "str | None" = None) 
             "sliding_window": int(window), "num_sliding_layers": int(n_sliding)}
 
 
+def kv_reservation_seqs(model_cfg: ModelConfig) -> int:
+    """Sequences to RESERVE KV for in budget mode: explicit kv_reservation_seqs, else max_num_seqs.
+
+    max_num_seqs is vLLM's scheduler width (launched as --max-num-seqs); kv_reservation_seqs lets you
+    reserve VRAM for FEWER concurrent sequences than that — so a model can admit many short requests
+    while packing tightly, with excess sequences queuing/paging within the reserved pool."""
+    return model_cfg.kv_reservation_seqs if model_cfg.kv_reservation_seqs else model_cfg.max_num_seqs
+
+
 async def estimate_model_need_mib(model_id: str, model_cfg: ModelConfig, effective_tp: int) -> "float | None":
     """Budget-mode per-card VRAM need (MiB) for a model = (weights + KV)/tp * factor + fixed margin.
 
-    Returns None when weights or the KV spec can't be determined (e.g. GGUF) — the caller then
-    falls back to sole-occupant discovery to measure the real footprint instead of guessing."""
+    KV is sized for kv_reservation_seqs (not the full max_num_seqs scheduler width). Returns None when
+    weights or the KV spec can't be determined (e.g. GGUF) — the caller then falls back to
+    sole-occupant discovery to measure the real footprint instead of guessing."""
     wbytes = await estimate_weight_bytes(model_id)
     if not wbytes:
         return None
@@ -1009,7 +1020,7 @@ async def estimate_model_need_mib(model_id: str, model_cfg: ModelConfig, effecti
     if not spec:
         return None
     kv_total = placement.kv_cache_mib(
-        max_model_len=model_cfg.max_model_len, max_num_seqs=model_cfg.max_num_seqs,
+        max_model_len=model_cfg.max_model_len, max_num_seqs=kv_reservation_seqs(model_cfg),
         num_layers=spec["num_layers"], num_kv_heads=spec["num_kv_heads"],
         head_dim=spec["head_dim"], dtype_bytes=spec["dtype_bytes"],
         sliding_window=spec.get("sliding_window", 0), num_sliding_layers=spec.get("num_sliding_layers", 0))
@@ -1441,7 +1452,8 @@ async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, e
                               effective_util, run_discovery, before_used, meas_gpu,
                               signature=None):
     """Start the container for an already-inserted LOADING `entry`, then flip it READY (or drop it
-    on failure — the single cleanup site).
+    on failure — the single cleanup site). `target_model_id` is the gateway IDENTITY (config name);
+    the vLLM `--model` is `model_cfg.repo`, so several named profiles can share one repo.
 
     After READY the footprint is set to GROUND TRUTH: the model's actual per-process VRAM
     (`measure_model_vram`). If attribution is unavailable (old driver / no compute-apps) the
@@ -1451,7 +1463,7 @@ async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, e
     try:
         try:
             runtime = await start_model_container(
-                target_model_id, entry.container_name, model_cfg,
+                model_cfg.repo, entry.container_name, model_cfg,
                 gpu_uuids=gpu_uuids, effective_tp=effective_tp, effective_util=effective_util)
         except BaseException:
             async with state_lock:
@@ -1592,14 +1604,15 @@ async def _ensure_started(target_model_id, model_cfg):
         wbytes = None
         if (len(pool_gpus) >= 2 and max_total > 0
                 and (max(pool_totals) - min(pool_totals)) <= 0.05 * max_total):
-            wbytes = await estimate_weight_bytes(target_model_id)
+            wbytes = await estimate_weight_bytes(model_cfg.repo)
         effective_tp = placement.compute_effective_tp(wbytes, model_cfg.tensor_parallel_size,
                                                       prior_tp, pool_totals, util)
 
     # Reuse a persisted footprint only when its signature matches the current sizing context;
     # otherwise treat the model as unseen and re-measure (fixes cross-mode / config-change staleness).
+    # Sizing depends on kv_reservation_seqs (the reserved KV), not max_num_seqs (scheduler width).
     current_sig = placement.footprint_signature(
-        PLACEMENT_MODE, model_cfg.max_model_len, model_cfg.max_num_seqs, effective_tp, util_basis=util)
+        PLACEMENT_MODE, model_cfg.max_model_len, kv_reservation_seqs(model_cfg), effective_tp, util_basis=util)
     seen = record is not None and placement.signature_matches(record, current_sig)
     is_discovery = not seen
     learned_mib = raw_learned_mib if seen else 0.0
@@ -1612,7 +1625,7 @@ async def _ensure_started(target_model_id, model_cfg):
     budget_need = None
     budget_discovery = False
     if budget_mode:
-        budget_need = await estimate_model_need_mib(target_model_id, model_cfg, effective_tp)
+        budget_need = await estimate_model_need_mib(model_cfg.repo, model_cfg, effective_tp)
         if budget_need is None:                 # GGUF / unknown arch -> can't estimate
             if learned_mib > 0:
                 budget_need = learned_mib       # reuse a previously measured footprint
@@ -1625,7 +1638,7 @@ async def _ensure_started(target_model_id, model_cfg):
         need_fn = (lambda g: learned_mib)
     else:
         need_fn = (lambda g: util * g.total)                # whole-card / discovery fallback
-    colocate_wbytes = await estimate_weight_bytes(target_model_id) if is_colocate else None
+    colocate_wbytes = await estimate_weight_bytes(model_cfg.repo) if is_colocate else None
 
     # DECIDE + reserve + insert LOADING — under state_lock (no I/O inside).
     async with state_lock:
@@ -1725,7 +1738,9 @@ async def proxy_request(request: Request):
     if not model_name or model_name not in ALLOWED_MODELS:
         return JSONResponse({"error": f"Model not allowed. Please choose from: {list(ALLOWED_MODELS.keys())}"}, status_code=400)
 
-    target_model_id = ALLOWED_MODELS[model_name]
+    # Identity is the config NAME (so several named profiles can share one repo, each its own
+    # container / footprint / queue). The repo (model_cfg.repo) is what vLLM serves under.
+    target_model_id = model_name
     model_cfg = MODEL_CONFIGS[model_name]
 
     # Initialize semaphore for this model if not exists
@@ -1829,7 +1844,7 @@ async def proxy_request(request: Request):
         current_queue_depth = model_queue_counts.get(target_model_id, 0)
 
         try:
-            body['model'] = target_model_id
+            body['model'] = model_cfg.repo  # vLLM serves under the repo it was launched with (--model)
             headers_to_forward = {
                 k: v for k, v in request.headers.items()
                 if k.lower() not in ('host', 'connection', 'content-length', 'transfer-encoding')

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -17,6 +17,9 @@ ALLOWED_CONFIG_KEYS = {
     "max_model_len",
     "tensor_parallel_size",
     "max_num_seqs",  # max concurrent sequences (vLLM --max-num-seqs); bounds KV-cache need in budget mode
+    "kv_reservation_seqs",  # budget mode: # of sequences to RESERVE KV for (default: max_num_seqs).
+                            # Set below max_num_seqs to allow high scheduler concurrency with a smaller
+                            # reserved KV pool (packs better; excess sequences queue/page).
     "quantization",
     "dtype",
     "inactivity_timeout",
@@ -41,6 +44,7 @@ class ModelConfig:
     max_model_len: int
     tensor_parallel_size: int
     max_num_seqs: int
+    kv_reservation_seqs: Optional[int]  # None -> reserve for max_num_seqs (full); else this many
     quantization: Optional[str]
     dtype: str
     inactivity_timeout: int
@@ -79,6 +83,12 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
     if max_num_seqs < 1:
         raise ValueError(f"model '{name}': 'max_num_seqs' must be >= 1, got {max_num_seqs}")
 
+    kv_reservation_seqs = merged["kv_reservation_seqs"]
+    if kv_reservation_seqs is not None:
+        kv_reservation_seqs = _require_int("kv_reservation_seqs", name, kv_reservation_seqs)
+        if kv_reservation_seqs < 1:
+            raise ValueError(f"model '{name}': 'kv_reservation_seqs' must be >= 1 or null, got {kv_reservation_seqs}")
+
     inactivity_timeout = _require_int("inactivity_timeout", name, merged["inactivity_timeout"])
     if inactivity_timeout < 0:
         raise ValueError(f"model '{name}': 'inactivity_timeout' must be >= 0, got {inactivity_timeout}")
@@ -114,6 +124,7 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
         max_model_len=int(max_model_len),
         tensor_parallel_size=int(tensor_parallel_size),
         max_num_seqs=int(max_num_seqs),
+        kv_reservation_seqs=(int(kv_reservation_seqs) if kv_reservation_seqs is not None else None),
         quantization=quantization,
         dtype=dtype,
         inactivity_timeout=int(inactivity_timeout),

--- a/gateway/placement.py
+++ b/gateway/placement.py
@@ -186,16 +186,19 @@ def kv_cache_mib(max_model_len, max_num_seqs, num_layers, num_kv_heads, head_dim
 
 # Canonical keys of a footprint "signature" — the inputs that determine a model's measured size.
 # A persisted footprint is reused only when its stored signature matches the current request's, so a
-# mode switch or a config change (context length / concurrency / TP / util basis) forces re-measure.
-_SIGNATURE_KEYS = ("mode", "max_model_len", "max_num_seqs", "effective_tp", "util_basis")
+# mode switch or a config change (context length / reserved KV seqs / TP / util basis) forces
+# re-measure. Sizing depends on kv_seqs (reserved sequences), NOT max_num_seqs (scheduler width).
+_SIGNATURE_KEYS = ("mode", "max_model_len", "kv_seqs", "effective_tp", "util_basis")
 
 
-def footprint_signature(mode, max_model_len, max_num_seqs, effective_tp, util_basis=0.0) -> dict:
-    """Build the signature stamped onto a footprint record (and compared on reuse)."""
+def footprint_signature(mode, max_model_len, kv_seqs, effective_tp, util_basis=0.0) -> dict:
+    """Build the signature stamped onto a footprint record (and compared on reuse).
+
+    kv_seqs is the number of sequences KV was reserved for (kv_reservation_seqs, else max_num_seqs)."""
     return {
         "mode": mode,
         "max_model_len": int(max_model_len),
-        "max_num_seqs": int(max_num_seqs),
+        "kv_seqs": int(kv_seqs),
         "effective_tp": int(effective_tp),
         "util_basis": round(float(util_basis), 4),
     }

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -23,6 +23,7 @@ BUILTINS = {
     "max_model_len": 0,
     "tensor_parallel_size": 1,
     "max_num_seqs": 16,
+    "kv_reservation_seqs": None,
     "quantization": None,
     "dtype": "auto",
     "inactivity_timeout": 1800,
@@ -332,6 +333,32 @@ def test_validate_budget_mode():
     # whole_card mode: no requirement, both pass.
     validate_budget_mode(unbounded, "whole_card")
     print("ok: validate_budget_mode")
+
+
+def test_kv_reservation_seqs():
+    cfgs = resolve_model_configs({"models": {
+        "a": {"repo": "o/a", "max_num_seqs": 32, "kv_reservation_seqs": 4},
+        "b": {"repo": "o/b"},  # unset -> None (falls back to max_num_seqs at runtime)
+    }}, BUILTINS)
+    assert cfgs["a"].kv_reservation_seqs == 4 and cfgs["a"].max_num_seqs == 32
+    assert cfgs["b"].kv_reservation_seqs is None
+    # null is explicitly allowed; <1 and bool are rejected
+    assert resolve_model_configs({"models": {"m": {"repo": "o/m", "kv_reservation_seqs": None}}},
+                                 BUILTINS)["m"].kv_reservation_seqs is None
+    _expect_error({"models": {"m": {"repo": "o/m", "kv_reservation_seqs": 0}}}, "kv_reservation_seqs")
+    _expect_error({"models": {"m": {"repo": "o/m", "kv_reservation_seqs": True}}}, "kv_reservation_seqs")
+    print("ok: kv_reservation_seqs")
+
+
+def test_same_repo_multiple_profiles():
+    # Two named profiles may share one repo (distinct identities, distinct configs).
+    cfgs = resolve_model_configs({"defaults": {"max_model_len": 8192}, "models": {
+        "fast": {"repo": "org/m", "max_num_seqs": 32, "kv_reservation_seqs": 4},
+        "long": {"repo": "org/m", "max_num_seqs": 2, "max_model_len": 32768},
+    }}, BUILTINS)
+    assert cfgs["fast"].repo == cfgs["long"].repo == "org/m"
+    assert cfgs["fast"].max_model_len == 8192 and cfgs["long"].max_model_len == 32768
+    print("ok: same repo, multiple profiles")
 
 
 def test_validate_extra_args_budget():


### PR DESCRIPTION
Two related budget-mode features so a single card can serve very different concurrency/context workloads.

## 1. `kv_reservation_seqs` — decouple concurrency from reserved VRAM
By default the gateway reserves KV for `max_model_len × max_num_seqs` (worst-case concurrency), which over-reserves for models that take many *short* requests (you saw `Deferred` backlogs with KV at 4.5%). The new optional per-model `kv_reservation_seqs` reserves KV for **fewer** sequences than the scheduler admits:

```yaml
judge-fast:
  repo: cyankiwi/Qwen3.5-4B-AWQ-4bit
  max_model_len: 8192
  max_num_seqs: 32          # admit up to 32 concurrent
  kv_reservation_seqs: 4    # reserve KV for 4 -> packs like a 4-way model; extras queue/page
```
Defaults to `max_num_seqs` (today's behavior). The footprint **signature** now keys on the reserved seq count, not the scheduler width, so changing `max_num_seqs` alone doesn't force a re-measure.

**Caveats:** doesn't guarantee N-way at *long* context (the rest defer); static pool; a tuning dial — but never an OOM (the util cap still holds).

## 2. Named profiles of one model (name-keyed identity)
Model identity is now the **config name** rather than the repo, so one repo can be registered under several names with different launch profiles (you can't change `max_model_len` per request, so this needs separate launches):

```yaml
coder-short: { repo: Qwen/Qwen2.5-Coder-7B-Instruct, max_model_len: 8192,  max_num_seqs: 16, kv_reservation_seqs: 4 }
coder-long:  { repo: Qwen/Qwen2.5-Coder-7B-Instruct, max_model_len: 32768, max_num_seqs: 1 }
```
The repo is still what vLLM serves under (`--model`, forwarded `body['model']`, HF lookups, download lock); the name keys the container / footprint / queue / start-lock / semaphore. **Caveat:** co-resident profiles of one repo load the weights into VRAM twice; otherwise the gateway swaps between them (reload on switch) — best used in batches.

## Notes
- Footprints are now keyed by config name, so a pre-existing repo-keyed `memory_footprints.json` is simply re-measured (signature-gated, safe) — old entries become harmless orphans.
- Independent of #18 (Xet weights); different functions, no conflict.
- 38 placement + 20 config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)