### PR TITLE
Add per-model request_defaults to hardcode default request params

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,15 @@ defaults:                      # optional; applies to all models
   inactivity_timeout: 1800     # seconds; 0 = never unload
   always_on: false
   extra_args: []               # raw vLLM CLI args, appended verbatim
+  request_defaults: {}         # request-body defaults, merged under each request (caller wins)
 models:                        # required, non-empty
   gemma3-4B:
     repo: google/gemma-3-4b-it
+  qwen3-30b:
+    repo: Qwen/Qwen3-30B-A3B
+    request_defaults:          # hardcode "thinking off" for this reasoning model
+      chat_template_kwargs:
+        enable_thinking: false
   qwen3-30b-awq:
     repo: cyankiwi/Qwen3-30B-A3B-Instruct-2507-AWQ-4bit
     quantization: awq          # per-model override
@@ -141,6 +147,14 @@ config: always `--model`, `--gpu-memory-utilization`, `--tensor-parallel-size`; 
 string is appended verbatim. `extra_args` override any flag the gateway generated (no
 duplicates). The final command is logged per model.
 
+**Per-model request defaults.** `request_defaults` (a mapping, default `{}`) is merged into each
+inference request body before it is forwarded to vLLM. **Caller-provided fields win** — these are
+defaults, not overrides, so a client can still opt back in by sending its own value. The merge is
+shallow (per top-level key): if the caller sends a key at all (e.g. its own `chat_template_kwargs`),
+their whole value replaces the default for that key. The gateway-managed `model` field may not be
+set here. Typical use: hardcode `chat_template_kwargs: {enable_thinking: false}` to keep a reasoning
+model's "thinking" off by default.
+
 **Lifecycle.** Containers whose model sets `always_on: true` (or `inactivity_timeout: 0`) are
 never auto-unloaded by the inactivity monitor; all others use their own resolved
 `inactivity_timeout`.
@@ -148,7 +162,8 @@ never auto-unloaded by the inactivity monitor; all others use their own resolved
 **Validation / fail-fast.** The file is validated at startup — `models` must be present and
 non-empty, every model needs a non-empty `repo`, unknown keys are rejected, and types/ranges
 are checked (`0 < gpu_memory_utilization <= 1`, integer fields must be integers, `extra_args`
-must be a list). Any error is logged and the gateway refuses to start.
+must be a list, `request_defaults` must be a mapping that doesn't set `model`). Any error is
+logged and the gateway refuses to start.
 
 **Backward compatibility.** If `MODELS_CONFIG_FILE` is missing, the gateway falls back to the
 legacy `ALLOWED_MODELS_JSON` env var with the global `VLLM_*` settings — behaving exactly as

--- a/config/models.yaml.example
+++ b/config/models.yaml.example
@@ -69,11 +69,25 @@ defaults:                      # optional; applied to every model unless overrid
   extra_args: []               # raw vLLM CLI args, appended verbatim. NOTE: --model,
                                # --gpu-memory-utilization and --tensor-parallel-size are
                                # gateway-managed (set from placement) and ignored here if present.
+  # request_defaults: {}       # mapping merged into each request body before forwarding to vLLM.
+                               # CALLER WINS: only fills keys the request didn't send (true defaults).
+                               # Shallow per top-level key — if the caller sends a key (e.g. its own
+                               # chat_template_kwargs) their whole value replaces the default for it.
+                               # May not set 'model' (gateway-managed). See qwen3-30b below.
 
 models:                        # required, non-empty
   # A small instruct model on its native context length (default pool: llm).
   gemma3-4B:
     repo: google/gemma-3-4b-it
+
+  # A reasoning model with "thinking" hardcoded OFF for every request. The gateway injects
+  # chat_template_kwargs.enable_thinking=false unless the caller sends its own chat_template_kwargs.
+  # (Uses the default pool 'llm'.)
+  qwen3-30b:
+    repo: Qwen/Qwen3-30B-A3B
+    request_defaults:
+      chat_template_kwargs:
+        enable_thinking: false
 
   # An AWQ-quantized model on the LLM pool.
   qwen3-30b-awq:

--- a/gateway/app.py
+++ b/gateway/app.py
@@ -19,7 +19,7 @@ from huggingface_hub import hf_hub_download, list_repo_files, HfApi
 import yaml
 import placement
 from config_loader import (
-    ModelConfig, resolve_model_configs, build_fallback_configs,
+    ModelConfig, resolve_model_configs, build_fallback_configs, merge_request_defaults,
     resolve_pools, validate_model_pools, validate_tp_against_pools, validate_colocate,
     validate_pools_visible, validate_budget_mode, validate_extra_args_budget, migrate_footprints,
 )
@@ -691,6 +691,7 @@ def builtin_model_defaults() -> dict:
         "extra_args": [],
         "pool": None,
         "colocate": False,
+        "request_defaults": {},
     }
 
 def load_model_configs() -> "tuple[dict, dict]":
@@ -1844,6 +1845,10 @@ async def proxy_request(request: Request):
         current_queue_depth = model_queue_counts.get(target_model_id, 0)
 
         try:
+            # Inject per-model request defaults UNDER the caller's body (caller wins). Must run
+            # before body['model'] is set (so repo always wins) and before is_streaming is read.
+            if model_cfg.request_defaults:
+                body = merge_request_defaults(model_cfg.request_defaults, body)
             body['model'] = model_cfg.repo  # vLLM serves under the repo it was launched with (--model)
             headers_to_forward = {
                 k: v for k, v in request.headers.items()

--- a/gateway/config_loader.py
+++ b/gateway/config_loader.py
@@ -8,6 +8,7 @@ Resolution precedence per setting:  per-model entry  >  defaults block  >  built
 default (the corresponding existing env var, supplied by the caller as ``builtins``).
 """
 
+import copy
 from dataclasses import dataclass
 from typing import Optional
 
@@ -27,6 +28,8 @@ ALLOWED_CONFIG_KEYS = {
     "extra_args",
     "pool",  # name of the GPU pool this model is placed in (multi-GPU); None = default pool
     "colocate",  # if true, may share a GPU with other co-locatable models (Phase 3)
+    "request_defaults",  # mapping merged UNDER each request body before forwarding (caller wins,
+                         # shallow per top-level key). e.g. chat_template_kwargs.enable_thinking=false.
 }
 
 # Per-model entries additionally require/allow "repo".
@@ -52,6 +55,7 @@ class ModelConfig:
     extra_args: list
     pool: Optional[str]  # GPU pool name (multi-GPU placement); None = the default/implicit pool
     colocate: bool  # may share a GPU with other co-locatable models (Phase 3)
+    request_defaults: dict  # request-body defaults merged under the caller's body before forwarding
 
 
 def _require_int(field: str, model: str, value):
@@ -117,6 +121,12 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
     if not isinstance(colocate, bool):
         raise ValueError(f"model '{name}': 'colocate' must be a boolean, got {colocate!r}")
 
+    request_defaults = merged["request_defaults"]
+    if not isinstance(request_defaults, dict):
+        raise ValueError(f"model '{name}': 'request_defaults' must be a mapping, got {request_defaults!r}")
+    if "model" in request_defaults:
+        raise ValueError(f"model '{name}': 'request_defaults' may not set 'model' (the gateway sets it from repo)")
+
     return ModelConfig(
         name=name,
         repo=repo,
@@ -133,7 +143,20 @@ def _construct(name: str, repo: str, merged: dict) -> ModelConfig:
         extra_args=[str(a) for a in extra_args],
         pool=pool.strip() if isinstance(pool, str) else None,
         colocate=colocate,
+        # Deep copy so a shared defaults.request_defaults mapping (and its nested dicts) is
+        # never aliased across models — mutating one model's copy can't leak into another.
+        request_defaults=copy.deepcopy(request_defaults),
     )
+
+
+def merge_request_defaults(defaults: dict, body: dict) -> dict:
+    """Shallow-merge per-model request defaults UNDER the caller's body (caller wins).
+
+    Merge is per top-level key: a key present in ``body`` keeps the caller's whole value;
+    keys only in ``defaults`` are injected. Returns a NEW dict (never mutates either input,
+    since ``body`` is the live request and ``defaults`` is the shared per-model config).
+    """
+    return {**defaults, **body}
 
 
 def resolve_model_configs(raw: dict, builtins: dict) -> "dict[str, ModelConfig]":

--- a/tests/test_config_resolution.py
+++ b/tests/test_config_resolution.py
@@ -12,7 +12,7 @@ import sys
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "gateway"))
 
 from config_loader import (  # noqa: E402
-    resolve_model_configs, build_fallback_configs, resolve_pools,
+    resolve_model_configs, build_fallback_configs, resolve_pools, merge_request_defaults,
     validate_model_pools, validate_tp_against_pools, validate_colocate,
     validate_pools_visible, validate_budget_mode, validate_extra_args_budget, migrate_footprints,
 )
@@ -31,6 +31,7 @@ BUILTINS = {
     "extra_args": [],
     "pool": None,
     "colocate": False,
+    "request_defaults": {},
 }
 
 
@@ -143,7 +144,70 @@ def test_fallback_matches_builtins():
     assert c.tensor_parallel_size == 1
     assert c.inactivity_timeout == 1800
     assert c.always_on is False
+    assert c.request_defaults == {}
     print("ok: fallback configs match builtins")
+
+
+def test_request_defaults_precedence():
+    """per-model request_defaults fully REPLACES defaults block, which replaces builtin {}.
+
+    Precedence across config tiers is whole-value replacement (the existing merged.update
+    semantics) — the shallow/caller merge only applies later, at request time.
+    """
+    raw = {
+        "defaults": {"request_defaults": {"chat_template_kwargs": {"enable_thinking": False}}},
+        "models": {
+            "inherits": {"repo": "o/a"},  # gets the defaults block value
+            "overrides": {"repo": "o/b", "request_defaults": {"temperature": 0}},  # replaces it
+            "none": {"repo": "o/c", "request_defaults": {}},  # explicit empty
+        },
+    }
+    cfgs = resolve_model_configs(raw, BUILTINS)
+    assert cfgs["inherits"].request_defaults == {"chat_template_kwargs": {"enable_thinking": False}}
+    assert cfgs["overrides"].request_defaults == {"temperature": 0}
+    assert cfgs["none"].request_defaults == {}
+    print("ok: request_defaults precedence")
+
+
+def test_request_defaults_isolation():
+    """Each model gets its own deep copy — no shared mutable (incl. nested dicts)."""
+    raw = {
+        "defaults": {"request_defaults": {"chat_template_kwargs": {"enable_thinking": False}}},
+        "models": {"x": {"repo": "o/x"}, "y": {"repo": "o/y"}},
+    }
+    cfgs = resolve_model_configs(raw, BUILTINS)
+    cfgs["x"].request_defaults["chat_template_kwargs"]["enable_thinking"] = True
+    cfgs["x"].request_defaults["added"] = 1
+    assert cfgs["y"].request_defaults == {"chat_template_kwargs": {"enable_thinking": False}}, \
+        "request_defaults leaked across models"
+    assert BUILTINS["request_defaults"] == {}, "builtins request_defaults was mutated"
+    print("ok: request_defaults isolated per model")
+
+
+def test_request_defaults_validation_errors():
+    # must be a mapping
+    _expect_error({"models": {"m": {"repo": "o/r", "request_defaults": "nope"}}}, "request_defaults")
+    # may not set the gateway-managed 'model' key
+    _expect_error({"models": {"m": {"repo": "o/r", "request_defaults": {"model": "x"}}}}, "request_defaults")
+    print("ok: request_defaults validation errors")
+
+
+def test_merge_request_defaults_helper():
+    """Shallow merge, caller wins per top-level key; inputs not mutated; new object."""
+    defaults = {"chat_template_kwargs": {"enable_thinking": False}, "temperature": 0}
+    body = {"messages": [], "chat_template_kwargs": {"enable_thinking": True}}
+    merged = merge_request_defaults(defaults, body)
+    # caller wins for a shared key (whole value replaced — documents the shallow tradeoff)
+    assert merged["chat_template_kwargs"] == {"enable_thinking": True}
+    # default-only key is injected
+    assert merged["temperature"] == 0
+    # caller-only key preserved
+    assert merged["messages"] == []
+    # inputs untouched; result is a new object
+    assert defaults == {"chat_template_kwargs": {"enable_thinking": False}, "temperature": 0}
+    assert body == {"messages": [], "chat_template_kwargs": {"enable_thinking": True}}
+    assert merged is not defaults and merged is not body
+    print("ok: merge_request_defaults helper")
 
 
 # --- pools (multi-GPU) ---


### PR DESCRIPTION
## What

Adds a per-model **`request_defaults`** mapping in `models.yaml`. The gateway merges it into each inference request body before forwarding to vLLM, so you can set default request parameters per model — e.g. hardcode "thinking off" for a reasoning model:

```yaml
models:
  qwen3-30b:
    repo: Qwen/Qwen3-30B-A3B
    request_defaults:
      chat_template_kwargs:
        enable_thinking: false
```

## Semantics

- **Caller wins** — `request_defaults` only fills keys the request didn't send. True defaults, so a client can still opt back in by sending its own value.
- **Shallow merge** per top-level key — if the caller sends a key at all (e.g. its own `chat_template_kwargs`), their whole value replaces the default for that key.
- The gateway-managed `model` field may not be set here (rejected at load).

## Changes

- **`gateway/config_loader.py`** — register `request_defaults` in `ALLOWED_CONFIG_KEYS` + the `ModelConfig` dataclass; validate (must be a mapping, no `model` key); `copy.deepcopy` per model so a shared `defaults` block isn't aliased; new `merge_request_defaults()` helper.
- **`gateway/app.py`** — add the builtin default `{}`; inject in `proxy_request` just before `body['model']` is set, covering both streaming and non-streaming paths. Guarded so the empty-default hot path stays allocation-free.
- **`tests/test_config_resolution.py`** — `BUILTINS` sync + 4 new tests (tier precedence, cross-model isolation incl. nested dict, validation rejection, merge helper). All 24 tests pass.
- **Docs** — `models.yaml.example` and `README.md` config reference.

## Non-interactions

`request_defaults` is request-time only — not read by command construction, placement sizing, or the footprint signature. No effect on VRAM accounting or budget mode.

## Verification

- `python3 tests/test_config_resolution.py` — all 24 pass.
- Example config resolves with `qwen3-30b.request_defaults == {'chat_template_kwargs': {'enable_thinking': False}}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)