### PR TITLE
Record per-GPU footprint for tensor-parallel models

### DIFF
--- a/gateway/app.py
+++ b/gateway/app.py
@@ -1603,9 +1603,15 @@ async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, e
                 measured = delta if delta > 256 else None
                 source = "gpu-delta"
             # 3) Last resort: keep the reserved estimate (already seeded into vram_footprint).
+            # vram_footprint / per_gpu_mib are PER-GPU (counted on each of the model's cards in
+            # _build_gpu_views). compute-apps SUMS usage across all the model's GPUs, so for a
+            # tensor-parallel model `measured` is the cross-card TOTAL -> divide by the TP degree to get
+            # the per-card share (weights+KV shard ~evenly across ranks). The gpu-delta path already
+            # samples a single card, and the reserved-estimate fallback is already per-card.
             if measured is not None and measured > 256:
-                entry.vram_footprint = measured
-                footprint_mib = measured
+                per_gpu_mib = (measured / max(1, effective_tp)) if source == "compute-apps" else measured
+                entry.vram_footprint = per_gpu_mib
+                footprint_mib = per_gpu_mib
             else:
                 footprint_mib = entry.reserved_mib
                 source = (source or "") + "/estimate-fallback"
@@ -1614,7 +1620,8 @@ async def _start_and_finalize(entry, target_model_id, model_cfg, *, gpu_uuids, e
                 "effective_util": float(effective_util or 0.0), "measured_at": time.time(),
                 "signature": signature}
             await save_known_footprints_async()
-            logging.info(f"Footprint for {target_model_id}: {int(footprint_mib)} MiB (via {source}).")
+            logging.info(f"Footprint for {target_model_id}: {int(footprint_mib)} MiB/GPU "
+                         f"(tp={effective_tp}, via {source}).")
         return entry
     finally:
         loading_tasks.pop(entry.container_name, None)  # release owner-liveness handle on every exit


### PR DESCRIPTION
## Summary

Follow-up to #21. Fixes a per-card accounting bug that breaks budget-mode packing when a tensor-parallel model shares a card with another model.

A `tp>1` model's footprint was **measured as the SUM across its cards** — `measure_model_vram` → `attribute_vram` sums per-process VRAM over all of the model's `gpu_uuids` — but then stored into `vram_footprint` / `known_footprints["per_gpu_mib"]` and counted on **each** of the model's cards in `_build_gpu_views`, fields that are per-GPU everywhere else.

So a card hosting a `tp=2` model looked **~2× as full as it actually was**, which:
1. wrongly rejected a second model from that card's genuine leftover budget — defeating budget-mode packing on a shared card; and
2. could stop the TP model itself from **reloading**, because its inflated `per_gpu_mib` was reused as the per-card need and exceeded the budget.

Observed live: a `tp=2` model recorded `per_gpu_mib: 25876`, larger than the 24 GB card it runs on — a two-card sum mislabeled as per-GPU.

## Fix

Divide the **compute-apps** total by `effective_tp` to get the per-card share (weights + KV shard ~evenly across TP ranks). The `gpu-delta` fallback samples a single card and the reserved-estimate fallback is already per-card, so only the compute-apps source is converted. `tp=1` is unchanged (`/1`).

## Test plan

- Full suite: **63 passed** (pure placement/config logic unchanged; this fix is in the docker-backed `_start_and_finalize`, not unit-tested here).

## Note for deployment

Existing persisted footprints from before this fix are still inflated and are reused on a signature match, so a previously-measured TP model keeps its wrong per-GPU value (and may stay unloadable). Clear stale TP entries from `MEMORY_FOOTPRINT_FILE` (default `/app/data/memory_footprints.json`) — or the whole file — so they get re-measured correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)